### PR TITLE
Add internal address and key derivation

### DIFF
--- a/src/Nerdbank.Zcash/NativeMethods.cs
+++ b/src/Nerdbank.Zcash/NativeMethods.cs
@@ -316,6 +316,60 @@ internal static unsafe partial class NativeMethods
 	}
 
 	/// <summary>
+	/// Derives the ivk value for a sapling incoming viewing key from elements of the full viewing key.
+	/// </summary>
+	/// <param name="fvk">The encoding of the public facing <see cref="Nerdbank.Zcash.Sapling.FullViewingKey"/>.</param>
+	/// <param name="dk">The encoding of the public facing <see cref="Nerdbank.Zcash.DiversifierKey"/> associated with the public full viewing key.</param>
+	/// <param name="internalFvk">Receives the encoded internal <see cref="Nerdbank.Zcash.Sapling.FullViewingKey"/>.</param>
+	/// <param name="internalDk">Receives the encoded internal <see cref="Nerdbank.Zcash.DiversifierKey"/>.</param>
+	/// <returns>0 on success, or a negative error code.</returns>
+	/// <exception cref="ArgumentException">Thrown if the provided buffers are not of expected length.</exception>
+	internal static int DeriveSaplingInternalFullViewingKey(ReadOnlySpan<byte> fvk, ReadOnlySpan<byte> dk, Span<byte> internalFvk, Span<byte> internalDk)
+	{
+		if (fvk.Length != 96 || dk.Length != 32 || internalFvk.Length != 96 || internalDk.Length != 32)
+		{
+			throw new ArgumentException();
+		}
+
+		fixed (byte* pFvk = fvk)
+		{
+			fixed (byte* pDk = dk)
+			{
+				fixed (byte* pInternalFvk = internalFvk)
+				{
+					fixed (byte* pInternalDk = internalDk)
+					{
+						return derive_internal_fvk_sapling(pFvk, pDk, pInternalFvk, pInternalDk);
+					}
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Derives the ivk value for a sapling incoming viewing key from elements of the full viewing key.
+	/// </summary>
+	/// <param name="extendedSpendingKey">The encoding of the public facing <see cref="Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey"/>.</param>
+	/// <param name="internalExtendedSpendingKey">Receives the encoded internal <see cref="Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey"/>.</param>
+	/// <returns>0 on success, or a negative error code.</returns>
+	/// <exception cref="ArgumentException">Thrown if the provided buffers are not of expected length.</exception>
+	internal static int DeriveSaplingInternalSpendingKey(ReadOnlySpan<byte> extendedSpendingKey, Span<byte> internalExtendedSpendingKey)
+	{
+		if (extendedSpendingKey.Length != 169 || internalExtendedSpendingKey.Length != 169)
+		{
+			throw new ArgumentException();
+		}
+
+		fixed (byte* pExtSK = extendedSpendingKey)
+		{
+			fixed (byte* pInternalExtSK = internalExtendedSpendingKey)
+			{
+				return derive_internal_sk_sapling(pExtSK, pInternalExtSK);
+			}
+		}
+	}
+
+	/// <summary>
 	/// Derives an Orchard full viewing key from a spending key.
 	/// </summary>
 	/// <param name="sk">A pointer to a 32-byte buffer containing the spending key.</param>
@@ -363,4 +417,10 @@ internal static unsafe partial class NativeMethods
 
 	[DllImport(LibraryName)]
 	private static extern int derive_sapling_ivk_from_fvk(byte* ak, byte* nk, byte* ivk);
+
+	[DllImport(LibraryName)]
+	private static extern int derive_internal_fvk_sapling(byte* fvk, byte* dk, byte* internal_fvk, byte* internal_dk);
+
+	[DllImport(LibraryName)]
+	private static extern int derive_internal_sk_sapling(byte* ext_sk, byte* internal_ext_sk);
 }

--- a/src/Nerdbank.Zcash/NativeMethods.cs
+++ b/src/Nerdbank.Zcash/NativeMethods.cs
@@ -12,6 +12,28 @@ internal static unsafe partial class NativeMethods
 	private const string LibraryName = "nerdbank_zcash_rust";
 
 	/// <summary>
+	/// Passes a byte buffer through the Orchard ToScalar method in the spec.
+	/// </summary>
+	/// <param name="uniformBytes">A 64-byte buffer.</param>
+	/// <param name="repr">A 32-byte buffer to receive the processed bytes.</param>
+	/// <returns>A return code.</returns>
+	internal static int OrchardToScalarToRepr(ReadOnlySpan<byte> uniformBytes, Span<byte> repr)
+	{
+		if (uniformBytes.Length != 64 || repr.Length != 32)
+		{
+			throw new ArgumentException();
+		}
+
+		fixed (byte* pUniformBytes = uniformBytes)
+		{
+			fixed (byte* pRepr = repr)
+			{
+				return orchard_to_scalar_to_repr(pUniformBytes, pRepr);
+			}
+		}
+	}
+
+	/// <summary>
 	/// Derives an Orchard full viewing key from a spending key.
 	/// </summary>
 	/// <param name="spendingKey">A 32-byte buffer containing the spending key.</param>
@@ -423,4 +445,7 @@ internal static unsafe partial class NativeMethods
 
 	[DllImport(LibraryName)]
 	private static extern int derive_internal_sk_sapling(byte* ext_sk, byte* internal_ext_sk);
+
+	[DllImport(LibraryName)]
+	private static extern int orchard_to_scalar_to_repr(byte* uniform_bytes, byte* repr);
 }

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -191,6 +191,7 @@ Nerdbank.Zcash.Pool.Sprout = 1 -> Nerdbank.Zcash.Pool
 Nerdbank.Zcash.Pool.Transparent = 0 -> Nerdbank.Zcash.Pool
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.CheckReceiver(Nerdbank.Zcash.SaplingReceiver receiver) -> bool
+Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.DeriveInternal() -> Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey!
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.Equals(Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey? other) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey
@@ -278,6 +279,7 @@ Nerdbank.Zcash.ZcashAccount.BirthdayHeight.init -> void
 Nerdbank.Zcash.ZcashAccount.DefaultAddress.get -> Nerdbank.Zcash.UnifiedAddress!
 Nerdbank.Zcash.ZcashAccount.FullViewing.get -> Nerdbank.Zcash.ZcashAccount.FullViewingKeys?
 Nerdbank.Zcash.ZcashAccount.FullViewingKeys
+Nerdbank.Zcash.ZcashAccount.FullViewingKeys.Internal.get -> Nerdbank.Zcash.ZcashAccount.InternalFullViewingKeys!
 Nerdbank.Zcash.ZcashAccount.FullViewingKeys.Orchard.get -> Nerdbank.Zcash.Orchard.FullViewingKey?
 Nerdbank.Zcash.ZcashAccount.FullViewingKeys.Sapling.get -> Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey?
 Nerdbank.Zcash.ZcashAccount.FullViewingKeys.Transparent.get -> Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey?
@@ -290,9 +292,14 @@ Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys.Orchard.get -> Nerdbank.Zcash.Or
 Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys.Sapling.get -> Nerdbank.Zcash.Sapling.IncomingViewingKey?
 Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys.Transparent.get -> Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey?
 Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys.UnifiedKey.get -> Nerdbank.Zcash.UnifiedViewingKey.Incoming!
+Nerdbank.Zcash.ZcashAccount.InternalFullViewingKeys
+Nerdbank.Zcash.ZcashAccount.InternalFullViewingKeys.Sapling.get -> Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey?
+Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys
+Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys.Sapling.get -> Nerdbank.Zcash.Sapling.ExpandedSpendingKey?
 Nerdbank.Zcash.ZcashAccount.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.ZcashAccount.Spending.get -> Nerdbank.Zcash.ZcashAccount.SpendingKeys?
 Nerdbank.Zcash.ZcashAccount.SpendingKeys
+Nerdbank.Zcash.ZcashAccount.SpendingKeys.Internal.get -> Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys!
 Nerdbank.Zcash.ZcashAccount.SpendingKeys.Orchard.get -> Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey?
 Nerdbank.Zcash.ZcashAccount.SpendingKeys.Sapling.get -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey?
 Nerdbank.Zcash.ZcashAccount.SpendingKeys.Transparent.get -> Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey?
@@ -385,6 +392,7 @@ Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Depth.get -> byte
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.DerivationPath.get -> Nerdbank.Cryptocurrencies.Bip32HDWallet.KeyPath?
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.DerivationPath.init -> void
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Derive(uint childIndex) -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey!
+Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.DeriveInternal() -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Encoded.get -> string!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Equals(Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey? other) -> bool
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Fingerprint.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyFingerprint
@@ -400,8 +408,10 @@ Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Depth.get -> byte
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.DerivationPath.get -> Nerdbank.Cryptocurrencies.Bip32HDWallet.KeyPath?
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.DerivationPath.init -> void
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Derive(uint childIndex) -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey!
+Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.DeriveInternal() -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Encoded.get -> string!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Equals(Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey? other) -> bool
+Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.ExpandedSpendingKey.get -> Nerdbank.Zcash.Sapling.ExpandedSpendingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.ExtendedFullViewingKey.get -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Fingerprint.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyFingerprint
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.FullViewingKey.get -> Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey!

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -149,6 +149,7 @@ Nerdbank.Zcash.Memo.ProprietaryData.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.Memo.ProprietaryData.set -> void
 Nerdbank.Zcash.Memo.RawBytes.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.Orchard.FullViewingKey
+Nerdbank.Zcash.Orchard.FullViewingKey.DeriveInternal() -> Nerdbank.Zcash.Orchard.FullViewingKey!
 Nerdbank.Zcash.Orchard.FullViewingKey.Equals(Nerdbank.Zcash.Orchard.FullViewingKey? other) -> bool
 Nerdbank.Zcash.Orchard.FullViewingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Orchard.IncomingViewingKey!
 Nerdbank.Zcash.Orchard.FullViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
@@ -293,6 +294,7 @@ Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys.Sapling.get -> Nerdbank.Zcash.Sa
 Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys.Transparent.get -> Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey?
 Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys.UnifiedKey.get -> Nerdbank.Zcash.UnifiedViewingKey.Incoming!
 Nerdbank.Zcash.ZcashAccount.InternalFullViewingKeys
+Nerdbank.Zcash.ZcashAccount.InternalFullViewingKeys.Orchard.get -> Nerdbank.Zcash.Orchard.FullViewingKey?
 Nerdbank.Zcash.ZcashAccount.InternalFullViewingKeys.Sapling.get -> Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey?
 Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys
 Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys.Sapling.get -> Nerdbank.Zcash.Sapling.ExpandedSpendingKey?

--- a/src/Nerdbank.Zcash/Sapling/ExpandedSpendingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/ExpandedSpendingKey.cs
@@ -76,7 +76,7 @@ public class ExpandedSpendingKey : IEquatable<ExpandedSpendingKey>, ISpendingKey
 	IIncomingViewingKey IFullViewingKey.IncomingViewingKey => this.IncomingViewingKey;
 
 	/// <summary>
-	/// Gets the ask component of the spending key.
+	/// Gets the spend authorization key.
 	/// </summary>
 	internal ref readonly Bytes32 Ask => ref this.ask;
 

--- a/src/Nerdbank.Zcash/ZcashAccount.cs
+++ b/src/Nerdbank.Zcash/ZcashAccount.cs
@@ -288,6 +288,10 @@ public class ZcashAccount
 	/// <summary>
 	/// Spending keys for the internal addresses.
 	/// </summary>
+	/// <remarks>
+	/// There is no orchard key in this class because for orchard, the public address spending key implicitly
+	/// has spending authority over the internal address.
+	/// </remarks>
 	public record InternalSpendingKeys
 	{
 		/// <summary>
@@ -381,12 +385,18 @@ public class ZcashAccount
 		internal InternalFullViewingKeys(FullViewingKeys fvk)
 		{
 			this.Sapling = fvk.Sapling?.DeriveInternal();
+			this.Orchard = fvk.Orchard?.DeriveInternal();
 		}
 
 		/// <summary>
 		/// Gets the sapling viewing key.
 		/// </summary>
 		public Sapling.DiversifiableFullViewingKey? Sapling { get; }
+
+		/// <summary>
+		/// Gets the orchard viewing key.
+		/// </summary>
+		public Orchard.FullViewingKey? Orchard { get; }
 	}
 
 	/// <summary>

--- a/src/Nerdbank.Zcash/ZcashAccount.cs
+++ b/src/Nerdbank.Zcash/ZcashAccount.cs
@@ -247,6 +247,8 @@ public class ZcashAccount
 				transparent?.FullViewingKey,
 				sapling?.FullViewingKey,
 				orchard?.FullViewingKey);
+
+			this.Internal = new(this);
 		}
 
 		/// <summary>
@@ -270,12 +272,37 @@ public class ZcashAccount
 		public Zip32HDWallet.Orchard.ExtendedSpendingKey? Orchard { get; }
 
 		/// <summary>
+		/// Gets the spending keys for the internal addresses used for change and shielding.
+		/// </summary>
+		public InternalSpendingKeys Internal { get; }
+
+		/// <summary>
 		/// Gets the full viewing key.
 		/// </summary>
 		internal FullViewingKeys FullViewingKey { get; }
 
 		/// <inheritdoc/>
 		IFullViewingKey ISpendingKey.FullViewingKey => this.FullViewingKey;
+	}
+
+	/// <summary>
+	/// Spending keys for the internal addresses.
+	/// </summary>
+	public record InternalSpendingKeys
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="InternalSpendingKeys"/> class.
+		/// </summary>
+		/// <param name="spendingKeys">The public spending keys from which to derive the internal keys.</param>
+		internal InternalSpendingKeys(SpendingKeys spendingKeys)
+		{
+			this.Sapling = spendingKeys.Sapling?.DeriveInternal().ExpandedSpendingKey;
+		}
+
+		/// <summary>
+		/// Gets the key for the sapling pool.
+		/// </summary>
+		public Sapling.ExpandedSpendingKey? Sapling { get; }
 	}
 
 	/// <summary>
@@ -304,6 +331,8 @@ public class ZcashAccount
 				transparent?.IncomingViewingKey,
 				sapling?.IncomingViewingKey,
 				orchard?.IncomingViewingKey);
+
+			this.Internal = new(this);
 		}
 
 		/// <summary>
@@ -327,12 +356,37 @@ public class ZcashAccount
 		public Orchard.FullViewingKey? Orchard { get; }
 
 		/// <summary>
+		/// Gets the full viewing keys for the internal addresses used for change and shielding.
+		/// </summary>
+		public InternalFullViewingKeys Internal { get; }
+
+		/// <summary>
 		/// Gets the incoming viewing key.
 		/// </summary>
 		internal IncomingViewingKeys IncomingViewingKey { get; }
 
 		/// <inheritdoc/>
 		IIncomingViewingKey IFullViewingKey.IncomingViewingKey => this.IncomingViewingKey;
+	}
+
+	/// <summary>
+	/// Full viewing keys for the internal (change and shielding) addresses.
+	/// </summary>
+	public record InternalFullViewingKeys
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="InternalFullViewingKeys"/> class.
+		/// </summary>
+		/// <param name="fvk">The public viewing keys from which to derive the internal ones.</param>
+		internal InternalFullViewingKeys(FullViewingKeys fvk)
+		{
+			this.Sapling = fvk.Sapling?.DeriveInternal();
+		}
+
+		/// <summary>
+		/// Gets the sapling viewing key.
+		/// </summary>
+		public Sapling.DiversifiableFullViewingKey? Sapling { get; }
 	}
 
 	/// <summary>

--- a/src/Nerdbank.Zcash/ZcashUtilities.cs
+++ b/src/Nerdbank.Zcash/ZcashUtilities.cs
@@ -33,25 +33,25 @@ internal static class ZcashUtilities
 	}
 
 	/// <inheritdoc cref="PRFexpand(ReadOnlySpan{byte}, PrfExpandCodes, ReadOnlySpan{byte}, Span{byte})"/>
-	internal static int PRFexpand(ReadOnlySpan<byte> sk, PrfExpandCodes domainSpecifier, Span<byte> output) => PRFexpand(sk, domainSpecifier, default, output);
+	internal static int PRFexpand(ReadOnlySpan<byte> first, PrfExpandCodes domainSpecifier, Span<byte> output) => PRFexpand(first, domainSpecifier, default, output);
 
 	/// <summary>
 	/// Applies a Blake2b_512 hash to the concatenation of a pair of buffers.
 	/// </summary>
-	/// <param name="sk">The first input buffer.</param>
+	/// <param name="first">The first input buffer.</param>
 	/// <param name="domainSpecifier">The byte that is unique for the caller's purpose.</param>
-	/// <param name="t">The second input buffer.</param>
+	/// <param name="second">The second input buffer.</param>
 	/// <param name="output">The buffer to receive the hash. Must be at least 64 bytes in length.</param>
 	/// <returns>The number of bytes written to <paramref name="output"/>. Always 64.</returns>
-	internal static int PRFexpand(ReadOnlySpan<byte> sk, PrfExpandCodes domainSpecifier, ReadOnlySpan<byte> t, Span<byte> output)
+	internal static int PRFexpand(ReadOnlySpan<byte> first, PrfExpandCodes domainSpecifier, ReadOnlySpan<byte> second, Span<byte> output)
 	{
 		Requires.Argument(output.Length >= 64, nameof(output), SharedStrings.FormatUnexpectedLength(64, output.Length));
 
 		// Rather than copy the input data into a single buffer, we could use an instance of Blake2B and call Update on it once for each input buffer.
-		Span<byte> buffer = stackalloc byte[sk.Length + 1 + t.Length];
-		sk.CopyTo(buffer);
-		buffer[sk.Length] = (byte)domainSpecifier;
-		t.CopyTo(buffer[(sk.Length + 1)..]);
+		Span<byte> buffer = stackalloc byte[first.Length + 1 + second.Length];
+		first.CopyTo(buffer);
+		buffer[first.Length] = (byte)domainSpecifier;
+		second.CopyTo(buffer[(first.Length + 1)..]);
 		return Blake2B.ComputeHash(buffer, output, new Blake2B.Config { Personalization = "Zcash_ExpandSeed"u8, OutputSizeInBytes = 512 / 8 });
 	}
 

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.ExtendedFullViewingKey.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.ExtendedFullViewingKey.cs
@@ -146,6 +146,17 @@ public partial class Zip32HDWallet
 				return Decode(childAsBytes, this.Network);
 			}
 
+			/// <inheritdoc cref="DiversifiableFullViewingKey.DeriveInternal"/>
+			public ExtendedFullViewingKey DeriveInternal()
+			{
+				return new ExtendedFullViewingKey(
+					this.FullViewingKey.DeriveInternal(),
+					this.ChainCode,
+					this.ParentFullViewingKeyTag,
+					this.Depth,
+					this.ChildIndex);
+			}
+
 			/// <inheritdoc/>
 			public bool Equals(ExtendedFullViewingKey? other)
 			{

--- a/src/nerdbank-zcash-rust/cargoTomlTargets/others/Cargo.lock
+++ b/src/nerdbank-zcash-rust/cargoTomlTargets/others/Cargo.lock
@@ -1676,11 +1676,13 @@ dependencies = [
 name = "nerdbank-zcash-rust"
 version = "0.1.0"
 dependencies = [
+ "ff 0.13.0",
  "group 0.13.0",
  "http",
  "jubjub",
  "lazy_static",
  "orchard",
+ "pasta_curves",
  "thiserror",
  "tokio",
  "uniffi",

--- a/src/nerdbank-zcash-rust/cargoTomlTargets/others/Cargo.toml
+++ b/src/nerdbank-zcash-rust/cargoTomlTargets/others/Cargo.toml
@@ -12,11 +12,13 @@ crate-type = ["cdylib"]
 uniffi = { version = "0.23.0", features = [ "build" ] }
 
 [dependencies]
+ff = "0.13.0"
 group = "0.13.0"
 http = "0.2.9"
 jubjub = "0.10.0"
 lazy_static = "1.4.0"
 orchard = "0.5.0"
+pasta_curves = "0.5.1"
 thiserror = "1.0.47"
 tokio = "1.32.0"
 uniffi = "0.23.0"

--- a/src/nerdbank-zcash-rust/cargoTomlTargets/win-arm64/Cargo.lock
+++ b/src/nerdbank-zcash-rust/cargoTomlTargets/win-arm64/Cargo.lock
@@ -1676,11 +1676,13 @@ dependencies = [
 name = "nerdbank-zcash-rust"
 version = "0.1.0"
 dependencies = [
+ "ff 0.13.0",
  "group 0.13.0",
  "http",
  "jubjub",
  "lazy_static",
  "orchard",
+ "pasta_curves",
  "thiserror",
  "tokio",
  "uniffi",

--- a/src/nerdbank-zcash-rust/cargoTomlTargets/win-arm64/Cargo.toml
+++ b/src/nerdbank-zcash-rust/cargoTomlTargets/win-arm64/Cargo.toml
@@ -12,11 +12,13 @@ crate-type = ["cdylib"]
 uniffi = { version = "0.23.0", features = [ "build" ] }
 
 [dependencies]
+ff = "0.13.0"
 group = "0.13.0"
 http = "0.2.9"
 jubjub = "0.10.0"
 lazy_static = "1.4.0"
 orchard = "0.5.0"
+pasta_curves = "0.5.1"
 thiserror = "1.0.47"
 tokio = "1.32.0"
 uniffi = "0.23.0"

--- a/src/nerdbank-zcash-rust/src/orchard.rs
+++ b/src/nerdbank-zcash-rust/src/orchard.rs
@@ -1,7 +1,9 @@
+use group::ff::{FromUniformBytes, PrimeField};
 use orchard::{
     keys::{DiversifierIndex, FullViewingKey, IncomingViewingKey, Scope, SpendingKey},
     Address,
 };
+use pasta_curves::pallas;
 
 #[no_mangle]
 pub extern "C" fn decrypt_orchard_diversifier(
@@ -107,4 +109,15 @@ pub extern "C" fn get_orchard_raw_payment_address_from_ivk(
         }
         None => -1,
     }
+}
+
+#[no_mangle]
+pub extern "C" fn orchard_to_scalar_to_repr(uniform_bytes: *const [u8; 64], repr: *mut [u8; 32]) -> i32 {
+    let uniform_bytes = unsafe { &*uniform_bytes };
+    let repr = unsafe { &mut *repr };
+
+    let repr_bytes = pallas::Scalar::from_uniform_bytes(uniform_bytes).to_repr();
+    repr.copy_from_slice(&repr_bytes);
+
+    0
 }

--- a/test/Nerdbank.Zcash.Tests/Orchard/FullViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Orchard/FullViewingKeyTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Nerdbank.Zcash.Orchard;
+
+namespace Orchard;
+
+public class FullViewingKeyTests : TestBase
+{
+	private readonly ITestOutputHelper logger;
+
+	public FullViewingKeyTests(ITestOutputHelper logger)
+	{
+		this.logger = logger;
+	}
+
+	[Fact]
+	public void DeriveInternal()
+	{
+		FullViewingKey fvk = new Zip32HDWallet(Mnemonic, ZcashNetwork.MainNet).CreateOrchardAccount().FullViewingKey;
+		this.logger.WriteLine($"Public address: {fvk.IncomingViewingKey.DefaultAddress}");
+		FullViewingKey internalFvk = fvk.DeriveInternal();
+		this.logger.WriteLine($"Internal address: {internalFvk.IncomingViewingKey.DefaultAddress}");
+		Assert.Equal("u1pxm93mp9jct7h5u7rref63mht9eqcskhsw86q3dntj7pt8w3jqj6vscsx09fz4z5lc277t4vpcexc46vus7twg3n8szv0cnucuzneuhh", internalFvk.IncomingViewingKey.DefaultAddress);
+	}
+}

--- a/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
@@ -88,6 +88,27 @@ public class Zip32HDWalletTests : TestBase
 	}
 
 	[Fact]
+	public void DeriveSaplingInternalSpendingKey()
+	{
+		Zip32HDWallet.Sapling.ExtendedSpendingKey sk = Zip32HDWallet.Sapling.Create(Mnemonic, ZcashNetwork.MainNet);
+		this.logger.WriteLine($"Public address: {sk.DefaultAddress}");
+		Zip32HDWallet.Sapling.ExtendedSpendingKey internalSk = sk.DeriveInternal();
+		this.logger.WriteLine($"Internal address: {internalSk.DefaultAddress}");
+		Assert.Equal("zs18uhw2dm7qwydasu5axkj9e38tygeqy36pep62nv83963z6l3fzdsg9kn2gqwtf6ckzk9khh4sxf", internalSk.DefaultAddress);
+		Assert.Equal(internalSk.DefaultAddress, internalSk.ExtendedFullViewingKey.DefaultAddress);
+	}
+
+	[Fact]
+	public void DeriveSaplingInternalFullViewingKey()
+	{
+		Zip32HDWallet.Sapling.ExtendedFullViewingKey fvk = Zip32HDWallet.Sapling.Create(Mnemonic, ZcashNetwork.MainNet).ExtendedFullViewingKey;
+		this.logger.WriteLine($"Public address: {fvk.DefaultAddress}");
+		Zip32HDWallet.Sapling.ExtendedFullViewingKey internalSk = fvk.DeriveInternal();
+		this.logger.WriteLine($"Internal address: {internalSk.DefaultAddress}");
+		Assert.Equal("zs18uhw2dm7qwydasu5axkj9e38tygeqy36pep62nv83963z6l3fzdsg9kn2gqwtf6ckzk9khh4sxf", internalSk.DefaultAddress);
+	}
+
+	[Fact]
 	public void MnemonicCtorInitializesProperties()
 	{
 		Zip32HDWallet wallet = new(Mnemonic, ZcashNetwork.TestNet);


### PR DESCRIPTION
- Sapling internal keys require both spending and full viewing key variants.
- Orchard internal keys only require a full viewing key, since the spending key for the public address doubles as the spending key for the internal address.