### PR TITLE
Fix build_all.ps1 script on Windows Powershell

### DIFF
--- a/azure-pipelines/Get-RustTargets.ps1
+++ b/azure-pipelines/Get-RustTargets.ps1
@@ -1,12 +1,12 @@
-if ($IsWindows) {
-    ,'aarch64-pc-windows-msvc'
-    ,'x86_64-pc-windows-msvc'
-}
-elseif ($IsLinux) {
+if ($IsLinux) {
 #    ,'aarch64-unknown-linux-gnu'
     ,'x86_64-unknown-linux-gnu'
 }
 elseif ($IsMacOS) {
     ,'aarch64-apple-darwin'
     ,'x86_64-apple-darwin'
+}
+else { # Windows
+    ,'aarch64-pc-windows-msvc'
+    ,'x86_64-pc-windows-msvc'
 }


### PR DESCRIPTION
Before this, the script would no-op unless run on Powershell 7.