### PR TITLE
Add `ZcashAccount.TryImportAccount`

### DIFF
--- a/src/Nerdbank.Cryptocurrencies/DecodeError.cs
+++ b/src/Nerdbank.Cryptocurrencies/DecodeError.cs
@@ -62,4 +62,25 @@ public enum DecodeError
 	/// The key carries inconsistent data regarding its derivation.
 	/// </summary>
 	InvalidDerivationData,
+
+	/// <summary>
+	/// The address did not conform to a recognized type.
+	/// </summary>
+	UnrecognizedAddressType,
+
+	/// <summary>
+	/// The encoding carries an unrecognized human-readable part.
+	/// Perhaps the wrong decoder is being applied to the given string.
+	/// </summary>
+	UnrecognizedHRP,
+
+	/// <summary>
+	/// The encoding carries a valid key, but its type does not match the type expected by the caller.
+	/// </summary>
+	TypeMismatch,
+
+	/// <summary>
+	/// An unenumerated error occurred. See error message for details.
+	/// </summary>
+	Other,
 }

--- a/src/Nerdbank.Cryptocurrencies/IKeyWithTextEncoding.cs
+++ b/src/Nerdbank.Cryptocurrencies/IKeyWithTextEncoding.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.Cryptocurrencies;
+
+/// <summary>
+/// A cryptocurrency key with a standard text encoding.
+/// </summary>
+public interface IKeyWithTextEncoding : IKey
+{
+	/// <summary>
+	/// Gets the text encoding of this key.
+	/// </summary>
+	/// <remarks>
+	/// To instantiate the key from this encoding, use <see cref="TryDecode(string, out DecodeError?, out string?, out IKeyWithTextEncoding?)"/>.
+	/// </remarks>
+	string TextEncoding { get; }
+
+	/// <summary>
+	/// Deserializes the text encoding of a key.
+	/// </summary>
+	/// <param name="encoding">The text encoding of the key.</param>
+	/// <param name="decodeError">If unsuccessful, receives the error code that identifies the first failure encountered during decoding.</param>
+	/// <param name="errorMessage">If unsuccessful, receives the error message that explains the first failure encountered during decoding.</param>
+	/// <param name="key">If successful, receives the deserialized key.</param>
+	/// <returns><see langword="true" /> if decoding was successful; otherwise <see langword="false" />.</returns>
+	static abstract bool TryDecode(string encoding, [NotNullWhen(false)] out DecodeError? decodeError, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out IKeyWithTextEncoding? key);
+}

--- a/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
@@ -21,6 +21,7 @@ Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.DerivationPath.init -> v
 Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.ExtendedKeyBase(Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase! copyFrom) -> void
 Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.IsTestNet.get -> bool
 Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.ParentFingerprint.get -> System.ReadOnlySpan<byte>
+Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.TextEncoding.get -> string!
 Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.WriteBytes(System.Span<byte> destination) -> int
 Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedPrivateKey
 Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedPrivateKey.CryptographicKey.get -> NBitcoin.Secp256k1.ECPrivKey!
@@ -88,7 +89,11 @@ Nerdbank.Cryptocurrencies.DecodeError.InvalidDerivationData = 10 -> Nerdbank.Cry
 Nerdbank.Cryptocurrencies.DecodeError.InvalidKey = 9 -> Nerdbank.Cryptocurrencies.DecodeError
 Nerdbank.Cryptocurrencies.DecodeError.InvalidWord = 5 -> Nerdbank.Cryptocurrencies.DecodeError
 Nerdbank.Cryptocurrencies.DecodeError.NoSeparator = 3 -> Nerdbank.Cryptocurrencies.DecodeError
+Nerdbank.Cryptocurrencies.DecodeError.Other = 14 -> Nerdbank.Cryptocurrencies.DecodeError
+Nerdbank.Cryptocurrencies.DecodeError.TypeMismatch = 13 -> Nerdbank.Cryptocurrencies.DecodeError
 Nerdbank.Cryptocurrencies.DecodeError.UnexpectedLength = 7 -> Nerdbank.Cryptocurrencies.DecodeError
+Nerdbank.Cryptocurrencies.DecodeError.UnrecognizedAddressType = 11 -> Nerdbank.Cryptocurrencies.DecodeError
+Nerdbank.Cryptocurrencies.DecodeError.UnrecognizedHRP = 12 -> Nerdbank.Cryptocurrencies.DecodeError
 Nerdbank.Cryptocurrencies.DecodeError.UnrecognizedVersion = 8 -> Nerdbank.Cryptocurrencies.DecodeError
 Nerdbank.Cryptocurrencies.DecodingReader
 Nerdbank.Cryptocurrencies.DecodingReader.DecodingReader() -> void
@@ -161,6 +166,9 @@ Nerdbank.Cryptocurrencies.IExtendedKey.DerivationPath.get -> Nerdbank.Cryptocurr
 Nerdbank.Cryptocurrencies.IExtendedKey.Derive(uint childIndex) -> Nerdbank.Cryptocurrencies.IExtendedKey!
 Nerdbank.Cryptocurrencies.IKey
 Nerdbank.Cryptocurrencies.IKey.IsTestNet.get -> bool
+Nerdbank.Cryptocurrencies.IKeyWithTextEncoding
+Nerdbank.Cryptocurrencies.IKeyWithTextEncoding.TextEncoding.get -> string!
+Nerdbank.Cryptocurrencies.IKeyWithTextEncoding.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Cryptocurrencies.IKeyWithTextEncoding? key) -> bool
 Nerdbank.Cryptocurrencies.InvalidKeyException
 Nerdbank.Cryptocurrencies.InvalidKeyException.InvalidKeyException() -> void
 Nerdbank.Cryptocurrencies.InvalidKeyException.InvalidKeyException(string? message) -> void
@@ -196,8 +204,8 @@ static Nerdbank.Cryptocurrencies.Base58Check.GetMaxEncodedLength(int byteCount) 
 static Nerdbank.Cryptocurrencies.Base58Check.TryDecode(System.ReadOnlySpan<char> encoded, System.Span<byte> bytes, out Nerdbank.Cryptocurrencies.DecodeError? decodeResult, out string? errorMessage, out int bytesWritten) -> bool
 static Nerdbank.Cryptocurrencies.Bech32.GetDecodedLength(System.ReadOnlySpan<char> encoded) -> (int Tag, int Data)?
 static Nerdbank.Cryptocurrencies.Bech32.GetEncodedLength(int tagLength, int dataLength) -> int
-static Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.Parse(System.ReadOnlySpan<char> extendedKeyEncoding) -> Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase!
-static Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.TryParse(System.ReadOnlySpan<char> extendedKeyEncoding, out Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase? result, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage) -> bool
+static Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.Decode(System.ReadOnlySpan<char> extendedKeyEncoding) -> Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase!
+static Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedKeyBase? result) -> bool
 static Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedPrivateKey.Create(Nerdbank.Cryptocurrencies.Bip39Mnemonic! mnemonic, bool testNet = false) -> Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedPrivateKey!
 static Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedPrivateKey.Create(System.ReadOnlySpan<byte> seed, bool testNet = false) -> Nerdbank.Cryptocurrencies.Bip32HDWallet.ExtendedPrivateKey!
 static Nerdbank.Cryptocurrencies.Bip32HDWallet.KeyPath.operator !=(Nerdbank.Cryptocurrencies.Bip32HDWallet.KeyPath? left, Nerdbank.Cryptocurrencies.Bip32HDWallet.KeyPath? right) -> bool

--- a/src/Nerdbank.Zcash.Cli/UACommand.cs
+++ b/src/Nerdbank.Zcash.Cli/UACommand.cs
@@ -47,7 +47,7 @@ internal class UACommand
 
 		internal int Execute(CancellationToken cancellationToken)
 		{
-			if (!ZcashAddress.TryParse(this.UnifiedAddress, out ZcashAddress? parsed, out _, out string? errorMessage))
+			if (!ZcashAddress.TryDecode(this.UnifiedAddress, out _, out string? errorMessage, out ZcashAddress? parsed))
 			{
 				this.Console.Error.WriteLine(errorMessage);
 				return 1;
@@ -105,7 +105,7 @@ internal class UACommand
 			ZcashAddress[] receiverAddresses = new ZcashAddress[this.Receivers.Length];
 			for (int i = 0; i < this.Receivers.Length; i++)
 			{
-				if (!ZcashAddress.TryParse(this.Receivers[i], out ZcashAddress? addr, out _, out string? errorMessage))
+				if (!ZcashAddress.TryDecode(this.Receivers[i], out _, out string? errorMessage, out ZcashAddress? addr))
 				{
 					this.Console.Error.WriteLine(Strings.FormatInvalidAddress(this.Receivers[i], errorMessage));
 					return 1;

--- a/src/Nerdbank.Zcash.Cli/Utilities.cs
+++ b/src/Nerdbank.Zcash.Cli/Utilities.cs
@@ -36,7 +36,7 @@ internal static class Utilities
 
 	internal static ZcashAddress AddressParser(ArgumentResult result)
 	{
-		if (ZcashAddress.TryParse(result.Tokens[0].Value, out ZcashAddress? addr, out _, out string? errorMessage))
+		if (ZcashAddress.TryDecode(result.Tokens[0].Value, out _, out string? errorMessage, out ZcashAddress? addr))
 		{
 			return addr;
 		}
@@ -50,7 +50,7 @@ internal static class Utilities
 		ZcashAddress[] addresses = new ZcashAddress[result.Tokens.Count];
 		for (int i = 0; i < result.Tokens.Count; i++)
 		{
-			if (ZcashAddress.TryParse(result.Tokens[i].Value, out ZcashAddress? addr, out _, out string? errorMessage))
+			if (ZcashAddress.TryDecode(result.Tokens[i].Value, out _, out string? errorMessage, out ZcashAddress? addr))
 			{
 				addresses[i] = addr;
 			}

--- a/src/Nerdbank.Zcash.Web/Pages/Index.razor
+++ b/src/Nerdbank.Zcash.Web/Pages/Index.razor
@@ -65,7 +65,7 @@ This site is running locally in your browser and does not send any data to a ser
     private void ParseAddress()
     {
         this.interpretedAddress = this.address;
-        if (ZcashAddress.TryParse(this.address, out ZcashAddress? addr, out _, out errorMessage))
+        if (ZcashAddress.TryDecode(this.address, out _, out errorMessage, out ZcashAddress? addr))
         {
             this.network = addr.Network.ToString();
             this.transparentAddress = GetReceiverAddress<TransparentAddress>(addr);
@@ -105,7 +105,7 @@ This site is running locally in your browser and does not send any data to a ser
     {
         if (!string.IsNullOrWhiteSpace(this.userAddressList))
         {
-            var addrs = this.userAddressList.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Select(ZcashAddress.Parse).ToList();
+            var addrs = this.userAddressList.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Select(ZcashAddress.Decode).ToList();
             this.address = UnifiedAddress.Create(addrs).ToString();
             this.ParseAddress();
         }

--- a/src/Nerdbank.Zcash/LightWalletClient.cs
+++ b/src/Nerdbank.Zcash/LightWalletClient.cs
@@ -345,7 +345,7 @@ public class LightWalletClient : IDisposable
 		/// </summary>
 		/// <param name="d">The uniffi data to copy from.</param>
 		internal TransactionSendItem(TransactionSendDetail d)
-			: this(ZcashAddress.Parse(d.toAddress), ZatsToZEC(d.value), new Memo(d.memo.ToArray()), d.recipientUa is null ? null : (UnifiedAddress)ZcashAddress.Parse(d.recipientUa))
+			: this(ZcashAddress.Decode(d.toAddress), ZatsToZEC(d.value), new Memo(d.memo.ToArray()), d.recipientUa is null ? null : (UnifiedAddress)ZcashAddress.Decode(d.recipientUa))
 		{
 		}
 	}

--- a/src/Nerdbank.Zcash/NativeMethods.cs
+++ b/src/Nerdbank.Zcash/NativeMethods.cs
@@ -341,9 +341,9 @@ internal static unsafe partial class NativeMethods
 	/// Derives the ivk value for a sapling incoming viewing key from elements of the full viewing key.
 	/// </summary>
 	/// <param name="fvk">The encoding of the public facing <see cref="Nerdbank.Zcash.Sapling.FullViewingKey"/>.</param>
-	/// <param name="dk">The encoding of the public facing <see cref="Nerdbank.Zcash.DiversifierKey"/> associated with the public full viewing key.</param>
+	/// <param name="dk">The encoding of the public facing <see cref="DiversifierKey"/> associated with the public full viewing key.</param>
 	/// <param name="internalFvk">Receives the encoded internal <see cref="Nerdbank.Zcash.Sapling.FullViewingKey"/>.</param>
-	/// <param name="internalDk">Receives the encoded internal <see cref="Nerdbank.Zcash.DiversifierKey"/>.</param>
+	/// <param name="internalDk">Receives the encoded internal <see cref="DiversifierKey"/>.</param>
 	/// <returns>0 on success, or a negative error code.</returns>
 	/// <exception cref="ArgumentException">Thrown if the provided buffers are not of expected length.</exception>
 	internal static int DeriveSaplingInternalFullViewingKey(ReadOnlySpan<byte> fvk, ReadOnlySpan<byte> dk, Span<byte> internalFvk, Span<byte> internalDk)
@@ -371,8 +371,8 @@ internal static unsafe partial class NativeMethods
 	/// <summary>
 	/// Derives the ivk value for a sapling incoming viewing key from elements of the full viewing key.
 	/// </summary>
-	/// <param name="extendedSpendingKey">The encoding of the public facing <see cref="Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey"/>.</param>
-	/// <param name="internalExtendedSpendingKey">Receives the encoded internal <see cref="Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey"/>.</param>
+	/// <param name="extendedSpendingKey">The encoding of the public facing <see cref="Zip32HDWallet.Sapling.ExtendedSpendingKey"/>.</param>
+	/// <param name="internalExtendedSpendingKey">Receives the encoded internal <see cref="Zip32HDWallet.Sapling.ExtendedSpendingKey"/>.</param>
 	/// <returns>0 on success, or a negative error code.</returns>
 	/// <exception cref="ArgumentException">Thrown if the provided buffers are not of expected length.</exception>
 	internal static int DeriveSaplingInternalSpendingKey(ReadOnlySpan<byte> extendedSpendingKey, Span<byte> internalExtendedSpendingKey)

--- a/src/Nerdbank.Zcash/Orchard/FullViewingKey.cs
+++ b/src/Nerdbank.Zcash/Orchard/FullViewingKey.cs
@@ -46,7 +46,7 @@ public class FullViewingKey : IUnifiedEncodingElement, IFullViewingKey, IEquatab
 	int IUnifiedEncodingElement.UnifiedDataLength => 32 * 3;
 
 	/// <inheritdoc/>
-	string IKeyWithTextEncoding.TextEncoding => this.textEncoding ??= UnifiedViewingKey.Full.Create(this);
+	public string TextEncoding => this.textEncoding ??= UnifiedViewingKey.Full.Create(this);
 
 	/// <summary>
 	/// Gets the spend validating key.

--- a/src/Nerdbank.Zcash/Orchard/SpendingKey.cs
+++ b/src/Nerdbank.Zcash/Orchard/SpendingKey.cs
@@ -14,6 +14,7 @@ public class SpendingKey : ISpendingKey, IUnifiedEncodingElement
 	private const string Bech32mTestNetworkHRP = "secret-orchard-sk-test";
 
 	private readonly Bytes32 value;
+	private string? textEncoding;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="SpendingKey"/> class.
@@ -51,19 +52,24 @@ public class SpendingKey : ISpendingKey, IUnifiedEncodingElement
 	/// <summary>
 	/// Gets the Bech32m encoding of the spending key.
 	/// </summary>
-	public string Encoded
+	public string TextEncoding
 	{
 		get
 		{
-			Span<char> encodedChars = stackalloc char[512];
-			string hrp = this.Network switch
+			if (this.textEncoding is null)
 			{
-				ZcashNetwork.MainNet => Bech32mMainNetworkHRP,
-				ZcashNetwork.TestNet => Bech32mTestNetworkHRP,
-				_ => throw new NotSupportedException(),
-			};
-			int charLength = Bech32.Bech32m.Encode(hrp, this.value.Value, encodedChars);
-			return new string(encodedChars[..charLength]);
+				Span<char> encodedChars = stackalloc char[512];
+				string hrp = this.Network switch
+				{
+					ZcashNetwork.MainNet => Bech32mMainNetworkHRP,
+					ZcashNetwork.TestNet => Bech32mTestNetworkHRP,
+					_ => throw new NotSupportedException(),
+				};
+				int charLength = Bech32.Bech32m.Encode(hrp, this.value.Value, encodedChars);
+				this.textEncoding = new string(encodedChars[..charLength]);
+			}
+
+			return this.textEncoding;
 		}
 	}
 

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -203,12 +203,13 @@ Nerdbank.Zcash.Orchard.IncomingViewingKey.CreateReceiver(Nerdbank.Zcash.Diversif
 Nerdbank.Zcash.Orchard.IncomingViewingKey.DefaultAddress.get -> Nerdbank.Zcash.OrchardAddress!
 Nerdbank.Zcash.Orchard.IncomingViewingKey.Equals(Nerdbank.Zcash.Orchard.IncomingViewingKey? other) -> bool
 Nerdbank.Zcash.Orchard.IncomingViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
+Nerdbank.Zcash.Orchard.IncomingViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Orchard.IncomingViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.OrchardReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
 Nerdbank.Zcash.Orchard.SpendingKey
-Nerdbank.Zcash.Orchard.SpendingKey.Encoded.get -> string!
 Nerdbank.Zcash.Orchard.SpendingKey.FullViewingKey.get -> Nerdbank.Zcash.Orchard.FullViewingKey!
 Nerdbank.Zcash.Orchard.SpendingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Orchard.IncomingViewingKey!
 Nerdbank.Zcash.Orchard.SpendingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
+Nerdbank.Zcash.Orchard.SpendingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.OrchardAddress
 Nerdbank.Zcash.OrchardAddress.OrchardAddress(in Nerdbank.Zcash.OrchardReceiver receiver, Nerdbank.Zcash.ZcashNetwork network = Nerdbank.Zcash.ZcashNetwork.MainNet) -> void
 Nerdbank.Zcash.OrchardReceiver
@@ -394,17 +395,17 @@ Nerdbank.Zcash.Sapling.ExpandedSpendingKey.Equals(Nerdbank.Zcash.Sapling.Expande
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Sapling.IncomingViewingKey!
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.Sapling.FullViewingKey
-Nerdbank.Zcash.Sapling.FullViewingKey.Encoded.get -> string!
 Nerdbank.Zcash.Sapling.FullViewingKey.Equals(Nerdbank.Zcash.Sapling.FullViewingKey? other) -> bool
 Nerdbank.Zcash.Sapling.FullViewingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Sapling.IncomingViewingKey!
 Nerdbank.Zcash.Sapling.FullViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
+Nerdbank.Zcash.Sapling.FullViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Sapling.IncomingViewingKey
 Nerdbank.Zcash.Sapling.IncomingViewingKey.CheckReceiver(Nerdbank.Zcash.SaplingReceiver receiver) -> bool
 Nerdbank.Zcash.Sapling.IncomingViewingKey.CreateDefaultReceiver() -> Nerdbank.Zcash.SaplingReceiver
 Nerdbank.Zcash.Sapling.IncomingViewingKey.DefaultAddress.get -> Nerdbank.Zcash.SaplingAddress!
-Nerdbank.Zcash.Sapling.IncomingViewingKey.Encoded.get -> string!
 Nerdbank.Zcash.Sapling.IncomingViewingKey.Equals(Nerdbank.Zcash.Sapling.IncomingViewingKey? other) -> bool
 Nerdbank.Zcash.Sapling.IncomingViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
+Nerdbank.Zcash.Sapling.IncomingViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Sapling.IncomingViewingKey.TryCreateReceiver(ref Nerdbank.Zcash.DiversifierIndex diversifierIndex, out Nerdbank.Zcash.SaplingReceiver? receiver) -> bool
 Nerdbank.Zcash.Sapling.IncomingViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
 Nerdbank.Zcash.SaplingAddress
@@ -466,7 +467,7 @@ Nerdbank.Zcash.UnifiedViewingKey.GetEnumerator() -> System.Collections.Generic.I
 Nerdbank.Zcash.UnifiedViewingKey.GetViewingKey<T>() -> T?
 Nerdbank.Zcash.UnifiedViewingKey.Incoming
 Nerdbank.Zcash.UnifiedViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
-Nerdbank.Zcash.UnifiedViewingKey.ViewingKey.get -> string!
+Nerdbank.Zcash.UnifiedViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.ZcashAccount
 Nerdbank.Zcash.ZcashAccount.AddressSendsToThisAcount(Nerdbank.Zcash.ZcashAddress! address) -> bool
 Nerdbank.Zcash.ZcashAccount.BirthdayHeight.get -> ulong?
@@ -580,7 +581,6 @@ Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.Depth.get -> byte
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.DerivationPath.get -> Nerdbank.Cryptocurrencies.Bip32HDWallet.KeyPath?
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.DerivationPath.init -> void
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.Derive(uint childIndex) -> Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey!
-Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.Encoded.get -> string!
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.Equals(Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey? other) -> bool
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.Fingerprint.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyFingerprint
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.FullViewingKey.get -> Nerdbank.Zcash.Orchard.FullViewingKey!
@@ -588,6 +588,7 @@ Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.IncomingViewingKey.get 
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.ParentFullViewingKeyTag.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag
 Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.SpendingKey.get -> Nerdbank.Zcash.Orchard.SpendingKey!
+Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Zip32HDWallet.Sapling
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.ChainCode.get -> Nerdbank.Zcash.Zip32HDWallet.ChainCode
@@ -598,13 +599,13 @@ Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.DerivationPath.get -
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.DerivationPath.init -> void
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Derive(uint childIndex) -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.DeriveInternal() -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey!
-Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Encoded.get -> string!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Equals(Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey? other) -> bool
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Fingerprint.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyFingerprint
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.FullViewingKey.get -> Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Sapling.IncomingViewingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.ParentFullViewingKeyTag.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag
+Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.ChainCode.get -> Nerdbank.Zcash.Zip32HDWallet.ChainCode
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.ChildIndex.get -> uint
@@ -614,7 +615,6 @@ Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.DerivationPath.get -> N
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.DerivationPath.init -> void
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Derive(uint childIndex) -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.DeriveInternal() -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey!
-Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Encoded.get -> string!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Equals(Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey? other) -> bool
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.ExpandedSpendingKey.get -> Nerdbank.Zcash.Sapling.ExpandedSpendingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.ExtendedFullViewingKey.get -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey!
@@ -623,6 +623,7 @@ Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.FullViewingKey.get -> N
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Sapling.IncomingViewingKey!
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.ParentFullViewingKeyTag.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag
+Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Zip32HDWallet.Seed.get -> System.ReadOnlyMemory<byte>
 Nerdbank.Zcash.Zip32HDWallet.Transparent
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey
@@ -763,6 +764,8 @@ static Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.operator ==(Nerdb
 static Nerdbank.Zcash.ManagedLightWalletClient.CreateAsync(System.Uri! serverUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Nerdbank.Zcash.ManagedLightWalletClient!>
 static Nerdbank.Zcash.Memo.FromMessage(string? message) -> Nerdbank.Zcash.Memo
 static Nerdbank.Zcash.Memo.NoMemo.get -> Nerdbank.Zcash.Memo
+static Nerdbank.Zcash.Orchard.FullViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Orchard.FullViewingKey? key) -> bool
+static Nerdbank.Zcash.Orchard.IncomingViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Orchard.IncomingViewingKey? key) -> bool
 static Nerdbank.Zcash.OrchardReceiver.UnifiedReceiverTypeCode.get -> byte
 static Nerdbank.Zcash.RawTransaction.Decode(System.ReadOnlyMemory<byte> bytes) -> Nerdbank.Zcash.RawTransaction
 static Nerdbank.Zcash.RawTransaction.JSDescriptionBCTV14.Decode(ref Nerdbank.Cryptocurrencies.DecodingReader reader, uint transactionVersion) -> Nerdbank.Zcash.RawTransaction.JSDescriptionBCTV14
@@ -790,21 +793,21 @@ static Nerdbank.Zcash.RawTransaction.SproutFields.operator !=(Nerdbank.Zcash.Raw
 static Nerdbank.Zcash.RawTransaction.SproutFields.operator ==(Nerdbank.Zcash.RawTransaction.SproutFields left, Nerdbank.Zcash.RawTransaction.SproutFields right) -> bool
 static Nerdbank.Zcash.RawTransaction.TransparentFields.operator !=(Nerdbank.Zcash.RawTransaction.TransparentFields left, Nerdbank.Zcash.RawTransaction.TransparentFields right) -> bool
 static Nerdbank.Zcash.RawTransaction.TransparentFields.operator ==(Nerdbank.Zcash.RawTransaction.TransparentFields left, Nerdbank.Zcash.RawTransaction.TransparentFields right) -> bool
-static Nerdbank.Zcash.Sapling.FullViewingKey.FromEncoded(System.ReadOnlySpan<char> encoding) -> Nerdbank.Zcash.Sapling.FullViewingKey!
-static Nerdbank.Zcash.Sapling.IncomingViewingKey.FromEncoded(System.ReadOnlySpan<char> encoding) -> Nerdbank.Zcash.Sapling.IncomingViewingKey!
+static Nerdbank.Zcash.Sapling.FullViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.FullViewingKey? key) -> bool
+static Nerdbank.Zcash.Sapling.IncomingViewingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.IncomingViewingKey? key) -> bool
 static Nerdbank.Zcash.SaplingReceiver.UnifiedReceiverTypeCode.get -> byte
 static Nerdbank.Zcash.SproutReceiver.UnifiedReceiverTypeCode.get -> byte
 static Nerdbank.Zcash.TransparentP2PKHReceiver.UnifiedReceiverTypeCode.get -> byte
 static Nerdbank.Zcash.TransparentP2SHReceiver.UnifiedReceiverTypeCode.get -> byte
 static Nerdbank.Zcash.UnifiedAddress.Create(params Nerdbank.Zcash.ZcashAddress![]! receivers) -> Nerdbank.Zcash.UnifiedAddress!
 static Nerdbank.Zcash.UnifiedAddress.Create(System.Collections.Generic.IReadOnlyCollection<Nerdbank.Zcash.ZcashAddress!>! receivers) -> Nerdbank.Zcash.UnifiedAddress!
+static Nerdbank.Zcash.UnifiedViewingKey.Decode(string! unifiedViewingKey) -> Nerdbank.Zcash.UnifiedViewingKey!
 static Nerdbank.Zcash.UnifiedViewingKey.Full.Create(params Nerdbank.Zcash.IFullViewingKey![]! viewingKeys) -> Nerdbank.Zcash.UnifiedViewingKey.Full!
 static Nerdbank.Zcash.UnifiedViewingKey.Full.Create(System.Collections.Generic.IEnumerable<Nerdbank.Zcash.IFullViewingKey!>! viewingKeys) -> Nerdbank.Zcash.UnifiedViewingKey.Full!
 static Nerdbank.Zcash.UnifiedViewingKey.implicit operator string?(Nerdbank.Zcash.UnifiedViewingKey? viewingKey) -> string?
 static Nerdbank.Zcash.UnifiedViewingKey.Incoming.Create(params Nerdbank.Zcash.IIncomingViewingKey![]! viewingKeys) -> Nerdbank.Zcash.UnifiedViewingKey.Incoming!
 static Nerdbank.Zcash.UnifiedViewingKey.Incoming.Create(System.Collections.Generic.IEnumerable<Nerdbank.Zcash.IIncomingViewingKey!>! viewingKeys) -> Nerdbank.Zcash.UnifiedViewingKey.Incoming!
-static Nerdbank.Zcash.UnifiedViewingKey.Parse(string! unifiedViewingKey) -> Nerdbank.Zcash.UnifiedViewingKey!
-static Nerdbank.Zcash.UnifiedViewingKey.TryParse(string! unifiedViewingKey, out Nerdbank.Zcash.UnifiedViewingKey? result) -> bool
+static Nerdbank.Zcash.UnifiedViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.UnifiedViewingKey? key) -> bool
 static Nerdbank.Zcash.ZcashAccount.FullViewingKeys.operator !=(Nerdbank.Zcash.ZcashAccount.FullViewingKeys? left, Nerdbank.Zcash.ZcashAccount.FullViewingKeys? right) -> bool
 static Nerdbank.Zcash.ZcashAccount.FullViewingKeys.operator ==(Nerdbank.Zcash.ZcashAccount.FullViewingKeys? left, Nerdbank.Zcash.ZcashAccount.FullViewingKeys? right) -> bool
 static Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys.operator !=(Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys? left, Nerdbank.Zcash.ZcashAccount.IncomingViewingKeys? right) -> bool
@@ -815,12 +818,13 @@ static Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys.operator !=(Nerdbank.Zca
 static Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys.operator ==(Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys? left, Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys? right) -> bool
 static Nerdbank.Zcash.ZcashAccount.SpendingKeys.operator !=(Nerdbank.Zcash.ZcashAccount.SpendingKeys? left, Nerdbank.Zcash.ZcashAccount.SpendingKeys? right) -> bool
 static Nerdbank.Zcash.ZcashAccount.SpendingKeys.operator ==(Nerdbank.Zcash.ZcashAccount.SpendingKeys? left, Nerdbank.Zcash.ZcashAccount.SpendingKeys? right) -> bool
+static Nerdbank.Zcash.ZcashAccount.TryImportAccount(string! encodedKey, out Nerdbank.Zcash.ZcashAccount? account) -> bool
+static Nerdbank.Zcash.ZcashAddress.Decode(string! address) -> Nerdbank.Zcash.ZcashAddress!
 static Nerdbank.Zcash.ZcashAddress.implicit operator string?(Nerdbank.Zcash.ZcashAddress? address) -> string?
-static Nerdbank.Zcash.ZcashAddress.Parse(string! address) -> Nerdbank.Zcash.ZcashAddress!
-static Nerdbank.Zcash.ZcashAddress.TryParse(string! address, out Nerdbank.Zcash.ZcashAddress? result) -> bool
-static Nerdbank.Zcash.ZcashAddress.TryParse(string! address, out Nerdbank.Zcash.ZcashAddress? result, out Nerdbank.Zcash.ParseError? errorCode, out string? errorMessage) -> bool
+static Nerdbank.Zcash.ZcashAddress.TryDecode(string! address, out Nerdbank.Cryptocurrencies.DecodeError? errorCode, out string? errorMessage, out Nerdbank.Zcash.ZcashAddress? result) -> bool
 static Nerdbank.Zcash.ZcashUtilities.AsSecurity(this Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Cryptocurrencies.Exchanges.Security!
 static Nerdbank.Zcash.ZcashUtilities.GetTickerName(this Nerdbank.Zcash.ZcashNetwork network) -> string!
+static Nerdbank.Zcash.ZcashUtilities.TryParseKey(string! encodedKey, out Nerdbank.Cryptocurrencies.IKeyWithTextEncoding? key) -> bool
 static Nerdbank.Zcash.Zip302MemoFormat.DetectMemoFormat(System.ReadOnlySpan<byte> memo) -> Nerdbank.Zcash.Zip302MemoFormat.MemoFormat
 static Nerdbank.Zcash.Zip302MemoFormat.EncodeMessage(System.ReadOnlySpan<char> text, System.Span<byte> memo) -> void
 static Nerdbank.Zcash.Zip302MemoFormat.EncodeNoMemo(System.Span<byte> memo) -> void
@@ -836,13 +840,15 @@ static Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails.operator !=
 static Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails.operator ==(Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails? left, Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails? right) -> bool
 static Nerdbank.Zcash.Zip32HDWallet.Orchard.Create(Nerdbank.Cryptocurrencies.Bip39Mnemonic! mnemonic, Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey!
 static Nerdbank.Zcash.Zip32HDWallet.Orchard.Create(System.ReadOnlySpan<byte> seed, Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey!
-static Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.FromEncoded(System.ReadOnlySpan<char> encoding) -> Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey!
+static Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey? key) -> bool
 static Nerdbank.Zcash.Zip32HDWallet.Sapling.Create(Nerdbank.Cryptocurrencies.Bip39Mnemonic! mnemonic, Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey!
 static Nerdbank.Zcash.Zip32HDWallet.Sapling.Create(System.ReadOnlySpan<byte> seed, Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey!
-static Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.FromEncoded(System.ReadOnlySpan<char> encoding) -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey!
-static Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.FromEncoded(System.ReadOnlySpan<char> encoding) -> Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey!
+static Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedFullViewingKey? key) -> bool
+static Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Zip32HDWallet.Sapling.ExtendedSpendingKey? key) -> bool
 static Nerdbank.Zcash.Zip32HDWallet.Transparent.Create(Nerdbank.Cryptocurrencies.Bip39Mnemonic! mnemonic, Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey!
 static Nerdbank.Zcash.Zip32HDWallet.Transparent.Create(System.ReadOnlySpan<byte> seed, Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey!
+static Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey? key) -> bool
+static Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeResult, out string? errorMessage, out Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey? key) -> bool
 virtual Nerdbank.Zcash.LightWalletClient.SendProgress.<Clone>$() -> Nerdbank.Zcash.LightWalletClient.SendProgress!
 virtual Nerdbank.Zcash.LightWalletClient.SendProgress.EqualityContract.get -> System.Type!
 virtual Nerdbank.Zcash.LightWalletClient.SendProgress.Equals(Nerdbank.Zcash.LightWalletClient.SendProgress? other) -> bool

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -196,6 +196,7 @@ Nerdbank.Zcash.Orchard.FullViewingKey.DeriveInternal() -> Nerdbank.Zcash.Orchard
 Nerdbank.Zcash.Orchard.FullViewingKey.Equals(Nerdbank.Zcash.Orchard.FullViewingKey? other) -> bool
 Nerdbank.Zcash.Orchard.FullViewingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Orchard.IncomingViewingKey!
 Nerdbank.Zcash.Orchard.FullViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
+Nerdbank.Zcash.Orchard.FullViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Orchard.IncomingViewingKey
 Nerdbank.Zcash.Orchard.IncomingViewingKey.CheckReceiver(Nerdbank.Zcash.OrchardReceiver receiver) -> bool
 Nerdbank.Zcash.Orchard.IncomingViewingKey.CreateDefaultReceiver() -> Nerdbank.Zcash.OrchardReceiver

--- a/src/Nerdbank.Zcash/Sapling/IncomingViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/IncomingViewingKey.cs
@@ -9,13 +9,14 @@ namespace Nerdbank.Zcash.Sapling;
 /// A viewing key for incoming transactions.
 /// </summary>
 [DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
-public class IncomingViewingKey : IUnifiedEncodingElement, IIncomingViewingKey, IEquatable<IncomingViewingKey>
+public class IncomingViewingKey : IUnifiedEncodingElement, IIncomingViewingKey, IEquatable<IncomingViewingKey>, IKeyWithTextEncoding
 {
 	private const string Bech32MainNetworkHRP = "zivks";
 	private const string Bech32TestNetworkHRP = "zivktestsapling";
 
 	private readonly Bytes32 ivk;
 	private readonly DiversifierKey? dk;
+	private string? textEncoding;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="IncomingViewingKey"/> class.
@@ -55,21 +56,26 @@ public class IncomingViewingKey : IUnifiedEncodingElement, IIncomingViewingKey, 
 	/// <summary>
 	/// Gets the Bech32 encoding of the incoming viewing key.
 	/// </summary>
-	public string Encoded
+	public string TextEncoding
 	{
 		get
 		{
-			Span<byte> encodedBytes = stackalloc byte[32];
-			Span<char> encodedChars = stackalloc char[512];
-			int byteLength = this.Encode(encodedBytes);
-			string hrp = this.Network switch
+			if (this.textEncoding is null)
 			{
-				ZcashNetwork.MainNet => Bech32MainNetworkHRP,
-				ZcashNetwork.TestNet => Bech32TestNetworkHRP,
-				_ => throw new NotSupportedException(),
-			};
-			int charLength = Bech32.Original.Encode(hrp, encodedBytes[..byteLength], encodedChars);
-			return new string(encodedChars[..charLength]);
+				Span<byte> encodedBytes = stackalloc byte[32];
+				Span<char> encodedChars = stackalloc char[512];
+				int byteLength = this.Encode(encodedBytes);
+				string hrp = this.Network switch
+				{
+					ZcashNetwork.MainNet => Bech32MainNetworkHRP,
+					ZcashNetwork.TestNet => Bech32TestNetworkHRP,
+					_ => throw new NotSupportedException(),
+				};
+				int charLength = Bech32.Original.Encode(hrp, encodedBytes[..byteLength], encodedChars);
+				this.textEncoding = new string(encodedChars[..charLength]);
+			}
+
+			return this.textEncoding;
 		}
 	}
 
@@ -85,28 +91,51 @@ public class IncomingViewingKey : IUnifiedEncodingElement, IIncomingViewingKey, 
 
 	private string DebuggerDisplay => this.DefaultAddress;
 
+	/// <inheritdoc cref="IKeyWithTextEncoding.TryDecode(string, out DecodeError?, out string?, out IKeyWithTextEncoding?)"/>
+	static bool IKeyWithTextEncoding.TryDecode(string encoding, [NotNullWhen(false)] out DecodeError? decodeError, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out IKeyWithTextEncoding? key)
+	{
+		if (TryDecode(encoding, out decodeError, out errorMessage, out IncomingViewingKey? ivk))
+		{
+			key = ivk;
+			return true;
+		}
+
+		key = null;
+		return false;
+	}
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="IncomingViewingKey"/> class
 	/// from the bech32 encoding of an incoming viewing key as specified in ZIP-32.
 	/// </summary>
-	/// <param name="encoding">The bech32-encoded key.</param>
-	/// <returns>An initialized <see cref="IncomingViewingKey"/>.</returns>
-	/// <remarks>
-	/// This method can parse the output of the <see cref="Encoded"/> property.
-	/// </remarks>
-	public static IncomingViewingKey FromEncoded(ReadOnlySpan<char> encoding)
+	/// <inheritdoc cref="IKeyWithTextEncoding.TryDecode(string, out DecodeError?, out string?, out IKeyWithTextEncoding?)"/>
+	public static bool TryDecode(ReadOnlySpan<char> encoding, [NotNullWhen(false)] out DecodeError? decodeError, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out IncomingViewingKey? key)
 	{
 		Span<char> hrp = stackalloc char[50];
 		Span<byte> data = stackalloc byte[32];
-		(int tagLength, int dataLength) = Bech32.Original.Decode(encoding, hrp, data);
-		hrp = hrp[..tagLength];
-		ZcashNetwork network = hrp switch
+		if (!Bech32.Original.TryDecode(encoding, hrp, data, out decodeError, out errorMessage, out (int TagLength, int DataLength) length))
+		{
+			key = null;
+			return false;
+		}
+
+		hrp = hrp[..length.TagLength];
+		ZcashNetwork? network = hrp switch
 		{
 			Bech32MainNetworkHRP => ZcashNetwork.MainNet,
 			Bech32TestNetworkHRP => ZcashNetwork.TestNet,
-			_ => throw new InvalidKeyException($"Unexpected bech32 tag: {hrp}"),
+			_ => null,
 		};
-		return Decode(data[..dataLength], network);
+		if (network is null)
+		{
+			decodeError = DecodeError.UnrecognizedHRP;
+			errorMessage = $"Unexpected bech32 tag: {hrp}";
+			key = null;
+			return false;
+		}
+
+		key = Decode(data[..length.DataLength], network.Value);
+		return true;
 	}
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/SaplingAddress.cs
+++ b/src/Nerdbank.Zcash/SaplingAddress.cs
@@ -52,8 +52,8 @@ public class SaplingAddress : ZcashAddress
 	/// <inheritdoc/>
 	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<SaplingReceiver, TPoolReceiver>(this.receiver);
 
-	/// <inheritdoc cref="ZcashAddress.TryParse(string, out ZcashAddress?, out ParseError?, out string?)" />
-	internal static bool TryParse(string address, [NotNullWhen(true)] out SaplingAddress? result, [NotNullWhen(false)] out ParseError? errorCode, [NotNullWhen(false)] out string? errorMessage)
+	/// <inheritdoc cref="ZcashAddress.TryDecode(string, out DecodeError?, out string?, out ZcashAddress?)" />
+	internal static bool TryParse(string address, [NotNullWhen(false)] out DecodeError? errorCode, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out SaplingAddress? result)
 	{
 		ZcashNetwork? network =
 			address.StartsWith(MainNetHumanReadablePart, StringComparison.Ordinal) ? ZcashNetwork.MainNet :
@@ -62,7 +62,7 @@ public class SaplingAddress : ZcashAddress
 		if (network is null)
 		{
 			result = null;
-			errorCode = ParseError.UnrecognizedAddressType;
+			errorCode = DecodeError.UnrecognizedAddressType;
 			errorMessage = Strings.InvalidSaplingPreamble;
 			return false;
 		}
@@ -71,10 +71,9 @@ public class SaplingAddress : ZcashAddress
 		{
 			Span<char> tag = stackalloc char[tagLength];
 			Span<byte> data = stackalloc byte[dataLength];
-			if (!Bech32.Original.TryDecode(address, tag, data, out DecodeError? decodeError, out errorMessage, out _))
+			if (!Bech32.Original.TryDecode(address, tag, data, out errorCode, out errorMessage, out _))
 			{
 				result = null;
-				errorCode = DecodeToParseError(decodeError);
 				return false;
 			}
 
@@ -85,7 +84,7 @@ public class SaplingAddress : ZcashAddress
 		}
 
 		result = null;
-		errorCode = ParseError.UnrecognizedAddressType;
+		errorCode = DecodeError.UnrecognizedAddressType;
 		errorMessage = Strings.FormatInvalidXAddress("sapling");
 		return false;
 	}

--- a/src/Nerdbank.Zcash/SproutAddress.cs
+++ b/src/Nerdbank.Zcash/SproutAddress.cs
@@ -58,8 +58,8 @@ public class SproutAddress : ZcashAddress
 	/// <inheritdoc/>
 	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<SproutReceiver, TPoolReceiver>(this.receiver);
 
-	/// <inheritdoc cref="ZcashAddress.TryParse(string, out ZcashAddress?, out ParseError?, out string?)" />
-	internal static unsafe bool TryParse(string address, [NotNullWhen(true)] out SproutAddress? result, [NotNullWhen(false)] out ParseError? errorCode, [NotNullWhen(false)] out string? errorMessage)
+	/// <inheritdoc cref="ZcashAddress.TryDecode(string, out DecodeError?, out string?, out ZcashAddress?)" />
+	internal static unsafe bool TryParse(string address, [NotNullWhen(true)] out SproutAddress? result, [NotNullWhen(false)] out DecodeError? errorCode, [NotNullWhen(false)] out string? errorMessage)
 	{
 		ZcashNetwork? network =
 			address.StartsWith("zc", StringComparison.Ordinal) ? ZcashNetwork.MainNet :
@@ -68,16 +68,15 @@ public class SproutAddress : ZcashAddress
 		if (network is null)
 		{
 			result = null;
-			errorCode = ParseError.UnrecognizedAddressType;
+			errorCode = DecodeError.UnrecognizedAddressType;
 			errorMessage = Strings.InvalidSproutPreamble;
 			return false;
 		}
 
 		Span<byte> decoded = stackalloc byte[2 + sizeof(SproutReceiver)];
-		if (!Base58Check.TryDecode(address, decoded, out DecodeError? decodeError, out errorMessage, out _))
+		if (!Base58Check.TryDecode(address, decoded, out errorCode, out errorMessage, out _))
 		{
 			result = null;
-			errorCode = DecodeToParseError(decodeError);
 			return false;
 		}
 

--- a/src/Nerdbank.Zcash/Strings.es.resx
+++ b/src/Nerdbank.Zcash/Strings.es.resx
@@ -174,4 +174,7 @@
   <data name="UnsupportedTransactionVersion" xml:space="preserve">
     <value>Versión de transacción no compatible {version}.</value>
   </data>
+  <data name="ExpectedKeyNotContainedWithinUnifiedViewingKey" xml:space="preserve">
+    <value>La clave de visualización unificada no incluye el tipo de clave necesario para utilizar esta API.</value>
+  </data>
 </root>

--- a/src/Nerdbank.Zcash/Strings.resx
+++ b/src/Nerdbank.Zcash/Strings.resx
@@ -123,6 +123,9 @@
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>An error occurred while fetching metadata from the lightwallet server.</value>
   </data>
+  <data name="ExpectedKeyNotContainedWithinUnifiedViewingKey" xml:space="preserve">
+    <value>The unified viewing key does not include the key type required to use this API.</value>
+  </data>
   <data name="InvalidAddress" xml:space="preserve">
     <value>This address is invalid or unrecognized.</value>
   </data>

--- a/src/Nerdbank.Zcash/TransparentAddress.cs
+++ b/src/Nerdbank.Zcash/TransparentAddress.cs
@@ -22,16 +22,15 @@ public abstract class TransparentAddress : ZcashAddress
 	/// </summary>
 	internal static int DecodedLength => 22;
 
-	/// <inheritdoc cref="ZcashAddress.TryParse(string, out ZcashAddress?, out ParseError?, out string?)" />
-	internal static bool TryParse(string address, [NotNullWhen(true)] out TransparentAddress? result, [NotNullWhen(false)] out ParseError? errorCode, [NotNullWhen(false)] out string? errorMessage)
+	/// <inheritdoc cref="ZcashAddress.TryDecode(string, out DecodeError?, out string?, out ZcashAddress?)" />
+	internal static bool TryParse(string address, [NotNullWhen(false)] out DecodeError? errorCode, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out TransparentAddress? result)
 	{
 		if (address.StartsWith("t", StringComparison.OrdinalIgnoreCase) && address.Length > 2)
 		{
 			Span<byte> decoded = stackalloc byte[DecodedLength];
-			if (!Base58Check.TryDecode(address, decoded, out DecodeError? decodeError, out errorMessage, out _))
+			if (!Base58Check.TryDecode(address, decoded, out errorCode, out errorMessage, out _))
 			{
 				result = null;
-				errorCode = DecodeToParseError(decodeError);
 				return false;
 			}
 
@@ -45,7 +44,7 @@ public abstract class TransparentAddress : ZcashAddress
 
 			if (network is null)
 			{
-				errorCode = ParseError.InvalidAddress;
+				errorCode = DecodeError.UnrecognizedAddressType;
 				errorMessage = Strings.InvalidNetworkHeader;
 				result = null;
 				return false;
@@ -68,7 +67,7 @@ public abstract class TransparentAddress : ZcashAddress
 		}
 
 		result = null;
-		errorCode = ParseError.UnrecognizedAddressType;
+		errorCode = DecodeError.UnrecognizedAddressType;
 		errorMessage = Strings.UnrecognizedAddress;
 		return false;
 	}

--- a/src/Nerdbank.Zcash/UnifiedAddress.cs
+++ b/src/Nerdbank.Zcash/UnifiedAddress.cs
@@ -112,8 +112,8 @@ public abstract class UnifiedAddress : ZcashAddress
 		return new CompoundUnifiedAddress(unifiedChars, new(GetReceiversInPreferredOrder(receivers)));
 	}
 
-	/// <inheritdoc cref="ZcashAddress.TryParse(string, out ZcashAddress?, out ParseError?, out string?)" />
-	internal static bool TryParse(string address, [NotNullWhen(true)] out UnifiedAddress? result, [NotNullWhen(false)] out ParseError? errorCode, [NotNullWhen(false)] out string? errorMessage)
+	/// <inheritdoc cref="ZcashAddress.TryDecode(string, out DecodeError?, out string?, out ZcashAddress?)" />
+	internal static bool TryParse(string address, [NotNullWhen(false)] out DecodeError? errorCode, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out UnifiedAddress? result)
 	{
 		if (!UnifiedEncoding.TryDecode(address, out string? humanReadablePart, out IReadOnlyList<UnifiedEncoding.UnknownElement>? unknownElements, out errorCode, out errorMessage))
 		{
@@ -131,7 +131,7 @@ public abstract class UnifiedAddress : ZcashAddress
 				network = ZcashNetwork.TestNet;
 				break;
 			default:
-				errorCode = ParseError.UnrecognizedAddressType;
+				errorCode = DecodeError.UnrecognizedHRP;
 				errorMessage = Strings.UnrecognizedAddress;
 				result = null;
 				return false;

--- a/src/Nerdbank.Zcash/ZcashAccount.cs
+++ b/src/Nerdbank.Zcash/ZcashAccount.cs
@@ -133,7 +133,7 @@ public class ZcashAccount
 	/// <param name="encodedKey">The standard encoding of some key.</param>
 	/// <param name="account">Receives the initialized account, if parsing is successful.</param>
 	/// <returns><see langword="true" /> if <paramref name="encodedKey"/> was recognized as an encoding of some Zcash-related key; <see langword="false" /> otherwise.</returns>
-	public static bool TryImportAccount(string encodedKey, out ZcashAccount? account)
+	public static bool TryImportAccount(string encodedKey, [NotNullWhen(true)] out ZcashAccount? account)
 	{
 		account = null;
 		if (ZcashUtilities.TryParseKey(encodedKey, out IKeyWithTextEncoding? result))
@@ -142,18 +142,15 @@ public class ZcashAccount
 			{
 				account = new ZcashAccount(unifiedViewingKey);
 			}
-
-			if (result is ISpendingKey && result is Zip32HDWallet.IExtendedKey extendedSK)
+			else if (result is ISpendingKey && result is Zip32HDWallet.IExtendedKey extendedSK)
 			{
 				account = new ZcashAccount(SpendingKeys.FromKeys(extendedSK));
 			}
-
-			if (result is IFullViewingKey fvk)
+			else if (result is IFullViewingKey fvk)
 			{
 				account = new ZcashAccount(FullViewingKeys.FromKeys(fvk));
 			}
-
-			if (result is IIncomingViewingKey ivk)
+			else if (result is IIncomingViewingKey ivk)
 			{
 				account = new ZcashAccount(IncomingViewingKeys.FromKeys(ivk));
 			}
@@ -498,6 +495,10 @@ public class ZcashAccount
 				{
 					sapling = s;
 				}
+				else if (key is Zip32HDWallet.Sapling.ExtendedFullViewingKey extSapling)
+				{
+					sapling = extSapling.FullViewingKey;
+				}
 				else if (key is Orchard.FullViewingKey o)
 				{
 					orchard = o;
@@ -598,7 +599,7 @@ public class ZcashAccount
 			Sapling.IncomingViewingKey? sapling = null;
 			Orchard.IncomingViewingKey? orchard = null;
 
-			foreach (Zip32HDWallet.IExtendedKey key in incomingViewingKeys)
+			foreach (IIncomingViewingKey key in incomingViewingKeys)
 			{
 				if (key is Transparent.ExtendedViewingKey t)
 				{

--- a/src/Nerdbank.Zcash/Zip321PaymentRequestUris.cs
+++ b/src/Nerdbank.Zcash/Zip321PaymentRequestUris.cs
@@ -145,8 +145,9 @@ public static class Zip321PaymentRequestUris
 					return false;
 				}
 
-				if (!ZcashAddress.TryParse(addressChars.ToString(), out ZcashAddress? address, out errorCode, out errorMessage))
+				if (!ZcashAddress.TryDecode(addressChars.ToString(), out DecodeError? decodeError, out errorMessage, out ZcashAddress? address))
 				{
+					errorCode = decodeError.ToParseError();
 					return false;
 				}
 
@@ -226,8 +227,9 @@ public static class Zip321PaymentRequestUris
 				switch (paramName)
 				{
 					case AddressParam:
-						if (!ZcashAddress.TryParse(decodedValue, out ZcashAddress? address, out errorCode, out errorMessage))
+						if (!ZcashAddress.TryDecode(decodedValue, out DecodeError? decodeError, out errorMessage, out ZcashAddress? address))
 						{
+							errorCode = decodeError.ToParseError();
 							return false;
 						}
 

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Orchard.ExtendedSpendingKey.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Orchard.ExtendedSpendingKey.cs
@@ -13,10 +13,11 @@ public partial class Zip32HDWallet
 		/// A key capable of spending, extended so it can be used to derive child keys.
 		/// </summary>
 		[DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
-		public class ExtendedSpendingKey : IExtendedKey, ISpendingKey, IEquatable<ExtendedSpendingKey>
+		public class ExtendedSpendingKey : IExtendedKey, ISpendingKey, IEquatable<ExtendedSpendingKey>, IKeyWithTextEncoding
 		{
 			private const string Bech32MainNetworkHRP = "secret-orchard-extsk-main";
 			private const string Bech32TestNetworkHRP = "secret-orchard-extsk-test";
+			private string? textEncoding;
 
 			/// <summary>
 			/// Initializes a new instance of the <see cref="ExtendedSpendingKey"/> class.
@@ -77,21 +78,26 @@ public partial class Zip32HDWallet
 			/// <summary>
 			/// Gets the Bech32 encoding of the spending key.
 			/// </summary>
-			public string Encoded
+			public string TextEncoding
 			{
 				get
 				{
-					Span<byte> encodedBytes = stackalloc byte[169];
-					Span<char> encodedChars = stackalloc char[512];
-					int byteLength = this.Encode(encodedBytes);
-					string hrp = this.Network switch
+					if (this.textEncoding is null)
 					{
-						ZcashNetwork.MainNet => Bech32MainNetworkHRP,
-						ZcashNetwork.TestNet => Bech32TestNetworkHRP,
-						_ => throw new NotSupportedException(),
-					};
-					int charLength = Bech32.Original.Encode(hrp, encodedBytes[..byteLength], encodedChars);
-					return new string(encodedChars[..charLength]);
+						Span<byte> encodedBytes = stackalloc byte[169];
+						Span<char> encodedChars = stackalloc char[512];
+						int byteLength = this.Encode(encodedBytes);
+						string hrp = this.Network switch
+						{
+							ZcashNetwork.MainNet => Bech32MainNetworkHRP,
+							ZcashNetwork.TestNet => Bech32TestNetworkHRP,
+							_ => throw new NotSupportedException(),
+						};
+						int charLength = Bech32.Original.Encode(hrp, encodedBytes[..byteLength], encodedChars);
+						this.textEncoding = new string(encodedChars[..charLength]);
+					}
+
+					return this.textEncoding;
 				}
 			}
 
@@ -112,28 +118,51 @@ public partial class Zip32HDWallet
 
 			private string DebuggerDisplay => $"{this.DefaultAddress} ({this.DerivationPath})";
 
+			/// <inheritdoc cref="IKeyWithTextEncoding.TryDecode(string, out DecodeError?, out string?, out IKeyWithTextEncoding?)"/>
+			static bool IKeyWithTextEncoding.TryDecode(string encoding, [NotNullWhen(false)] out DecodeError? decodeError, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out IKeyWithTextEncoding? key)
+			{
+				if (TryDecode(encoding, out decodeError, out errorMessage, out ExtendedSpendingKey? sk))
+				{
+					key = sk;
+					return true;
+				}
+
+				key = null;
+				return false;
+			}
+
 			/// <summary>
 			/// Initializes a new instance of the <see cref="ExtendedSpendingKey"/> class
 			/// from the bech32 encoding of an extended spending key as specified in ZIP-32.
 			/// </summary>
-			/// <param name="encoding">The bech32-encoded key.</param>
-			/// <returns>An initialized <see cref="ExtendedSpendingKey"/>.</returns>
-			/// <remarks>
-			/// This method can parse the output of the <see cref="Encoded"/> property.
-			/// </remarks>
-			public static ExtendedSpendingKey FromEncoded(ReadOnlySpan<char> encoding)
+			/// <inheritdoc cref="IKeyWithTextEncoding.TryDecode(string, out DecodeError?, out string?, out IKeyWithTextEncoding?)"/>
+			public static bool TryDecode(ReadOnlySpan<char> encoding, [NotNullWhen(false)] out DecodeError? decodeError, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out ExtendedSpendingKey? key)
 			{
 				Span<char> hrp = stackalloc char[50];
 				Span<byte> data = stackalloc byte[169];
-				(int tagLength, int dataLength) = Bech32.Original.Decode(encoding, hrp, data);
-				hrp = hrp[..tagLength];
-				ZcashNetwork network = hrp switch
+				if (!Bech32.Original.TryDecode(encoding, hrp, data, out decodeError, out errorMessage, out (int TagLength, int DataLength) length))
+				{
+					key = null;
+					return false;
+				}
+
+				hrp = hrp[..length.TagLength];
+				ZcashNetwork? network = hrp switch
 				{
 					Bech32MainNetworkHRP => ZcashNetwork.MainNet,
 					Bech32TestNetworkHRP => ZcashNetwork.TestNet,
-					_ => throw new InvalidKeyException($"Unexpected bech32 tag: {hrp}"),
+					_ => null,
 				};
-				return Decode(data[..dataLength], network);
+				if (network is null)
+				{
+					decodeError = DecodeError.UnrecognizedHRP;
+					errorMessage = $"Unexpected bech32 tag: {hrp}";
+					key = null;
+					return false;
+				}
+
+				key = Decode(data[..length.DataLength], network.Value);
+				return true;
 			}
 
 			/// <inheritdoc/>

--- a/test/Nerdbank.Cryptocurrencies.Tests/ExtendedKeyBaseTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/ExtendedKeyBaseTests.cs
@@ -27,24 +27,24 @@ public class ExtendedKeyBaseTests : Bip32HDWalletTestBase
 	[InlineData("xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD5SDKr24z3aiUvKr9bJpdrcLg1y3G", DecodeError.InvalidKey)] // private key n not in 1..n-1
 	[InlineData("xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Q5JXayek4PRsn35jii4veMimro1xefsM58PgBMrvdYre8QyULY", DecodeError.InvalidKey)] // invalid pubkey 020000000000000000000000000000000000000000000000000000000000000007
 	[InlineData("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHL", DecodeError.InvalidChecksum)] // invalid checksum
-	public void ExtendedKey_TryParse(string base58Encoded, DecodeError expectedDecodeError)
+	public void ExtendedKey_TryDecode(string base58Encoded, DecodeError expectedDecodeError)
 	{
 		this.logger.WriteLine($"Decoding {base58Encoded}");
-		Assert.False(ExtendedKeyBase.TryParse(base58Encoded, out _, out DecodeError? decodeError, out string? errorMessage));
+		Assert.False(ExtendedKeyBase.TryDecode(base58Encoded, out DecodeError? decodeError, out string? errorMessage, out _));
 		this.logger.WriteLine($"DecodeError {decodeError}: {errorMessage}");
 		Assert.Equal(expectedDecodeError, decodeError.Value);
 	}
 
 	[Fact]
-	public void ExtendedKeyBase_TryParse_Empty()
+	public void ExtendedKeyBase_TryDecode_Empty()
 	{
-		Assert.False(ExtendedKeyBase.TryParse(string.Empty, out _, out DecodeError? decodeError, out string? errorMessage));
+		Assert.False(ExtendedKeyBase.TryDecode(string.Empty, out DecodeError? decodeError, out string? errorMessage, out _));
 		this.logger.WriteLine($"DecodeError {decodeError}: {errorMessage}");
 	}
 
 	[Fact]
-	public void ExtendedKeyBase_Parse()
+	public void ExtendedKeyBase_Decode()
 	{
-		Assert.Throws<FormatException>(() => ExtendedKeyBase.Parse("xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGpWnsj83BHtEy5Zt8CcDr1UiRXuWCmTQLxEK9vbz5gPstX92JQ"));
+		Assert.Throws<FormatException>(() => ExtendedKeyBase.Decode("xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGpWnsj83BHtEy5Zt8CcDr1UiRXuWCmTQLxEK9vbz5gPstX92JQ"));
 	}
 }

--- a/test/Nerdbank.Cryptocurrencies.Tests/ExtendedPrivateKeyTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/ExtendedPrivateKeyTests.cs
@@ -102,17 +102,17 @@ public class ExtendedPrivateKeyTests : Bip32HDWalletTestBase
 	}
 
 	[Fact]
-	public void Parse_Roundtripping()
+	public void Decode_Roundtripping()
 	{
 		using ExtendedPrivateKey pvk = ExtendedPrivateKey.Create(Bip39Mnemonic.Create(128));
 		string pvkAsString = pvk.ToString();
-		using ExtendedPrivateKey pvk2 = Assert.IsType<ExtendedPrivateKey>(ExtendedKeyBase.Parse(pvk.ToString()));
+		using ExtendedPrivateKey pvk2 = Assert.IsType<ExtendedPrivateKey>(ExtendedKeyBase.Decode(pvk.ToString()));
 		AssertEqual(pvkAsString, pvk2);
 
 		// Test parsing of derived keys.
 		using ExtendedPrivateKey pvkDerived = pvk.Derive(1);
 		string pvkDerivedAsString = pvkDerived.ToString();
-		using ExtendedPrivateKey pvkDerived2 = Assert.IsType<ExtendedPrivateKey>(ExtendedKeyBase.Parse(pvkDerived.ToString()));
+		using ExtendedPrivateKey pvkDerived2 = Assert.IsType<ExtendedPrivateKey>(ExtendedKeyBase.Decode(pvkDerived.ToString()));
 		AssertEqual(pvkDerivedAsString, pvkDerived2);
 	}
 

--- a/test/Nerdbank.Cryptocurrencies.Tests/ExtendedPublicKeyTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/ExtendedPublicKeyTests.cs
@@ -89,18 +89,18 @@ public class ExtendedPublicKeyTests : Bip32HDWalletTestBase
 	}
 
 	[Fact]
-	public void Parse_Roundtripping()
+	public void Decode_Roundtripping()
 	{
 		using ExtendedPrivateKey pvk = ExtendedPrivateKey.Create(Bip39Mnemonic.Create(128));
 		ExtendedPublicKey pub = pvk.PublicKey;
 		string pubAsString = pub.ToString();
-		ExtendedPublicKey pub2 = Assert.IsType<ExtendedPublicKey>(ExtendedKeyBase.Parse(pub.ToString()));
+		ExtendedPublicKey pub2 = Assert.IsType<ExtendedPublicKey>(ExtendedKeyBase.Decode(pub.ToString()));
 		AssertEqual(pubAsString, pub2);
 
 		// Test parsing of derived keys.
 		ExtendedPublicKey pubDerived = pub.Derive(1);
 		string pubDerivedAsString = pubDerived.ToString();
-		ExtendedPublicKey pubDerived2 = Assert.IsType<ExtendedPublicKey>(ExtendedKeyBase.Parse(pubDerived.ToString()));
+		ExtendedPublicKey pubDerived2 = Assert.IsType<ExtendedPublicKey>(ExtendedKeyBase.Decode(pubDerived.ToString()));
 		AssertEqual(pubDerivedAsString, pubDerived2);
 	}
 

--- a/test/Nerdbank.Zcash.Tests/Orchard/FullViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Orchard/FullViewingKeyTests.cs
@@ -8,6 +8,7 @@ namespace Orchard;
 public class FullViewingKeyTests : TestBase
 {
 	private readonly ITestOutputHelper logger;
+	private readonly FullViewingKey fvk = new Zip32HDWallet(Mnemonic, ZcashNetwork.MainNet).CreateOrchardAccount().FullViewingKey;
 
 	public FullViewingKeyTests(ITestOutputHelper logger)
 	{
@@ -17,10 +18,47 @@ public class FullViewingKeyTests : TestBase
 	[Fact]
 	public void DeriveInternal()
 	{
-		FullViewingKey fvk = new Zip32HDWallet(Mnemonic, ZcashNetwork.MainNet).CreateOrchardAccount().FullViewingKey;
-		this.logger.WriteLine($"Public address: {fvk.IncomingViewingKey.DefaultAddress}");
-		FullViewingKey internalFvk = fvk.DeriveInternal();
+		this.logger.WriteLine($"Public address: {this.fvk.IncomingViewingKey.DefaultAddress}");
+		FullViewingKey internalFvk = this.fvk.DeriveInternal();
 		this.logger.WriteLine($"Internal address: {internalFvk.IncomingViewingKey.DefaultAddress}");
 		Assert.Equal("u1pxm93mp9jct7h5u7rref63mht9eqcskhsw86q3dntj7pt8w3jqj6vscsx09fz4z5lc277t4vpcexc46vus7twg3n8szv0cnucuzneuhh", internalFvk.IncomingViewingKey.DefaultAddress);
+	}
+
+	[Fact]
+	public void TryDecode()
+	{
+		Assert.True(FullViewingKey.TryDecode(this.fvk.TextEncoding, out DecodeError? decodeError, out string? errorMessage, out FullViewingKey? imported));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.NotNull(imported);
+		Assert.Equal(this.fvk.TextEncoding, imported.TextEncoding);
+	}
+
+	[Fact]
+	public void TryDecode_ViaInterface()
+	{
+		Assert.True(TryDecodeViaInterface<FullViewingKey>(this.fvk.TextEncoding, out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? imported));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.NotNull(imported);
+		Assert.Equal(this.fvk.TextEncoding, imported.TextEncoding);
+	}
+
+	[Fact]
+	public void TryDecode_Fail()
+	{
+		Assert.False(FullViewingKey.TryDecode("fail", out DecodeError? decodeError, out string? errorMessage, out FullViewingKey? imported));
+		Assert.NotNull(decodeError);
+		Assert.NotNull(errorMessage);
+		Assert.Null(imported);
+	}
+
+	[Fact]
+	public void TryDecode_ViaInterface_Fail()
+	{
+		Assert.False(TryDecodeViaInterface<FullViewingKey>("fail", out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? imported));
+		Assert.NotNull(decodeError);
+		Assert.NotNull(errorMessage);
+		Assert.Null(imported);
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/Orchard/IncomingViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Orchard/IncomingViewingKeyTests.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Numerics;
+using Nerdbank.Zcash.Orchard;
 
 namespace Orchard;
 
 public class IncomingViewingKeyTests : TestBase
 {
+	private readonly IncomingViewingKey ivk = new Zip32HDWallet(Mnemonic, ZcashNetwork.MainNet).CreateOrchardAccount().IncomingViewingKey;
+
 	[Fact]
 	public void TryGetDiversifierIndex_And_CheckReceiver()
 	{
@@ -22,5 +25,43 @@ public class IncomingViewingKeyTests : TestBase
 		Assert.False(account2.IncomingViewingKey.CheckReceiver(receiver));
 		Assert.False(account2.IncomingViewingKey.TryGetDiversifierIndex(receiver, out idx));
 		Assert.Null(idx);
+	}
+
+	[Fact]
+	public void TryDecode()
+	{
+		Assert.True(IncomingViewingKey.TryDecode(this.ivk.TextEncoding, out DecodeError? decodeError, out string? errorMessage, out IncomingViewingKey? imported));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.NotNull(imported);
+		Assert.Equal(this.ivk.TextEncoding, imported.TextEncoding);
+	}
+
+	[Fact]
+	public void TryDecode_ViaInterface()
+	{
+		Assert.True(TryDecodeViaInterface<IncomingViewingKey>(this.ivk.TextEncoding, out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? imported));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.NotNull(imported);
+		Assert.Equal(this.ivk.TextEncoding, imported.TextEncoding);
+	}
+
+	[Fact]
+	public void TryDecode_Fail()
+	{
+		Assert.False(IncomingViewingKey.TryDecode("fail", out DecodeError? decodeError, out string? errorMessage, out IncomingViewingKey? imported));
+		Assert.NotNull(decodeError);
+		Assert.NotNull(errorMessage);
+		Assert.Null(imported);
+	}
+
+	[Fact]
+	public void TryDecode_ViaInterface_Fail()
+	{
+		Assert.False(TryDecodeViaInterface<IncomingViewingKey>("fail", out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? imported));
+		Assert.NotNull(decodeError);
+		Assert.NotNull(errorMessage);
+		Assert.Null(imported);
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/Orchard/SpendingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Orchard/SpendingKeyTests.cs
@@ -15,19 +15,19 @@ public class SpendingKeyTests : TestBase
 	}
 
 	[Fact]
-	public void Encoding_Test()
+	public void TextEncoding_Test()
 	{
 		SpendingKey key = new Zip32HDWallet(Mnemonic, ZcashNetwork.TestNet).CreateOrchardAccount().SpendingKey;
-		this.logger.WriteLine(key.Encoded);
-		Assert.Equal("secret-orchard-sk-test1whlyqth636qgqpeh3mfy388yqyc5uqe6r6r7avmyau0wkut764zskqcut8", key.Encoded);
+		this.logger.WriteLine(key.TextEncoding);
+		Assert.Equal("secret-orchard-sk-test1whlyqth636qgqpeh3mfy388yqyc5uqe6r6r7avmyau0wkut764zskqcut8", key.TextEncoding);
 	}
 
 	[Fact]
-	public void Encoding_Main()
+	public void TextEncoding_Main()
 	{
 		SpendingKey key = new Zip32HDWallet(Mnemonic, ZcashNetwork.MainNet).CreateOrchardAccount().SpendingKey;
-		this.logger.WriteLine(key.Encoded);
-		Assert.Equal("secret-orchard-sk-main1te7l50dm25afq89clh8r2ft34lufgxfyn0lwe6hxvvhyzfp3xfeqctpsk7", key.Encoded);
+		this.logger.WriteLine(key.TextEncoding);
+		Assert.Equal("secret-orchard-sk-main1te7l50dm25afq89clh8r2ft34lufgxfyn0lwe6hxvvhyzfp3xfeqctpsk7", key.TextEncoding);
 	}
 
 	[Theory, PairwiseData]

--- a/test/Nerdbank.Zcash.Tests/OrchardAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/OrchardAddressTests.cs
@@ -11,13 +11,13 @@ public class OrchardAddressTests : TestBase
 	}
 
 	[Fact]
-	public void TryParse_TestNet()
+	public void Decode_TestNet()
 	{
-		Assert.Equal(ZcashNetwork.TestNet, ZcashAddress.Parse(ValidUnifiedAddressOrchardTestNet).Network);
+		Assert.Equal(ZcashNetwork.TestNet, ZcashAddress.Decode(ValidUnifiedAddressOrchardTestNet).Network);
 	}
 
 	[Fact]
-	public void HasShieldedReceiver() => Assert.True(ZcashAddress.Parse(ValidUnifiedAddressOrchard).HasShieldedReceiver);
+	public void HasShieldedReceiver() => Assert.True(ZcashAddress.Decode(ValidUnifiedAddressOrchard).HasShieldedReceiver);
 
 	[Fact]
 	public void Ctor_Receiver_TestNet()

--- a/test/Nerdbank.Zcash.Tests/Sapling/DiversifiableFullViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Sapling/DiversifiableFullViewingKeyTests.cs
@@ -33,7 +33,7 @@ public class DiversifiableFullViewingKeyTests : TestBase
 	}
 
 	[Theory, PairwiseData]
-	public void Encoded_FromEncoded(bool testNet)
+	public void TextEncoding_TryDecode(bool testNet)
 	{
 		ZcashNetwork network = testNet ? ZcashNetwork.TestNet : ZcashNetwork.MainNet;
 		string expected = testNet
@@ -41,11 +41,11 @@ public class DiversifiableFullViewingKeyTests : TestBase
 			: "zxviews1qvqlw6pjqqqqpqrcxxrqd2acqcurzx7wat9gk7jv3wee36rj970d9h47fpg6fddwurue4vmrpg7g6hkdsw5hvuqtgd43ngt39x54nrej29rvc2cpajl7m0p3hdnt47rdgc5d949tgmqwx5mjujckqe8pvlgnupecd8fmgt6y5t6662jk4lkv8kjughx6x8vrn97pqcqn04wduse3n5hhlkf6qc5ah08udx9g0wpkf6rausju7yamzl6z4gdyrtmqs9ak93w0z222vgst458pe";
 		Zip32HDWallet wallet = new(Mnemonic, network);
 		Zip32HDWallet.Sapling.ExtendedSpendingKey account = wallet.CreateSaplingAccount(0);
-		string actual = account.ExtendedFullViewingKey.Encoded;
+		string actual = account.ExtendedFullViewingKey.TextEncoding;
 		this.logger.WriteLine(actual);
 		Assert.Equal(expected, actual);
 
-		var decoded = Zip32HDWallet.Sapling.ExtendedFullViewingKey.FromEncoded(actual);
+		Assert.True(Zip32HDWallet.Sapling.ExtendedFullViewingKey.TryDecode(actual, out _, out _, out Zip32HDWallet.Sapling.ExtendedFullViewingKey? decoded));
 		Assert.Equal(account.ExtendedFullViewingKey, decoded);
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/Sapling/FullViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Sapling/FullViewingKeyTests.cs
@@ -8,6 +8,7 @@ namespace Sapling;
 public class FullViewingKeyTests : TestBase
 {
 	private readonly ITestOutputHelper logger;
+	private readonly FullViewingKey fvk = new Zip32HDWallet(Mnemonic, ZcashNetwork.MainNet).CreateSaplingAccount().FullViewingKey;
 
 	public FullViewingKeyTests(ITestOutputHelper logger)
 	{
@@ -29,5 +30,43 @@ public class FullViewingKeyTests : TestBase
 
 		Assert.True(FullViewingKey.TryDecode(actual, out _, out _, out FullViewingKey? decoded));
 		Assert.Equal(account.FullViewingKey, decoded);
+	}
+
+	[Fact]
+	public void TryDecode()
+	{
+		Assert.True(FullViewingKey.TryDecode(this.fvk.TextEncoding, out DecodeError? decodeError, out string? errorMessage, out FullViewingKey? imported));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.NotNull(imported);
+		Assert.Equal(this.fvk.TextEncoding, imported.TextEncoding);
+	}
+
+	[Fact]
+	public void TryDecode_ViaInterface()
+	{
+		Assert.True(TryDecodeViaInterface<FullViewingKey>(this.fvk.TextEncoding, out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? imported));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.NotNull(imported);
+		Assert.Equal(this.fvk.TextEncoding, imported.TextEncoding);
+	}
+
+	[Fact]
+	public void TryDecode_Fail()
+	{
+		Assert.False(FullViewingKey.TryDecode("fail", out DecodeError? decodeError, out string? errorMessage, out FullViewingKey? imported));
+		Assert.NotNull(decodeError);
+		Assert.NotNull(errorMessage);
+		Assert.Null(imported);
+	}
+
+	[Fact]
+	public void TryDecode_ViaInterface_Fail()
+	{
+		Assert.False(TryDecodeViaInterface<FullViewingKey>("fail", out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? imported));
+		Assert.NotNull(decodeError);
+		Assert.NotNull(errorMessage);
+		Assert.Null(imported);
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/Sapling/FullViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Sapling/FullViewingKeyTests.cs
@@ -15,7 +15,7 @@ public class FullViewingKeyTests : TestBase
 	}
 
 	[Theory, PairwiseData]
-	public void Encoded_FromEncoded(bool testNet)
+	public void TextEncoding_TryDecode(bool testNet)
 	{
 		ZcashNetwork network = testNet ? ZcashNetwork.TestNet : ZcashNetwork.MainNet;
 		string expected = testNet
@@ -23,11 +23,11 @@ public class FullViewingKeyTests : TestBase
 			: "zviews1lxdtxcc28jx4anvr49m8qz6rdvv6zuff49vc7vj3gmxzkq0vhlkmcvdmv6a0sm2x9rfdf26xcr34xuhyk9sxfct86ylqwwrf6w6z739z7kkj5440anpa5hz9ek33mque0sgxqymatn0yxvva9alajwsx9yd8x6ty";
 		Zip32HDWallet wallet = new(Mnemonic, network);
 		Zip32HDWallet.Sapling.ExtendedSpendingKey account = wallet.CreateSaplingAccount(0);
-		string actual = account.FullViewingKey.Encoded;
+		string actual = account.FullViewingKey.TextEncoding;
 		this.logger.WriteLine(actual);
 		Assert.Equal(expected, actual);
 
-		var decoded = FullViewingKey.FromEncoded(actual);
+		Assert.True(FullViewingKey.TryDecode(actual, out _, out _, out FullViewingKey? decoded));
 		Assert.Equal(account.FullViewingKey, decoded);
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/Sapling/IncomingViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Sapling/IncomingViewingKeyTests.cs
@@ -16,7 +16,7 @@ public class IncomingViewingKeyTests : TestBase
 	}
 
 	[Theory, PairwiseData]
-	public void Encoded_FromEncoded(bool testNet)
+	public void TextEncoding_TryDecode(bool testNet)
 	{
 		ZcashNetwork network = testNet ? ZcashNetwork.TestNet : ZcashNetwork.MainNet;
 		string expected = testNet
@@ -24,12 +24,14 @@ public class IncomingViewingKeyTests : TestBase
 			: "zivks184h858g2g87ucf4jp3vqr0legsts34cn60xptenyz72rdrwvlvzsfwkpqh";
 		Zip32HDWallet wallet = new(Mnemonic, network);
 		Zip32HDWallet.Sapling.ExtendedSpendingKey account = wallet.CreateSaplingAccount(0);
-		string actual = account.FullViewingKey.IncomingViewingKey.Encoded;
+		string actual = account.FullViewingKey.IncomingViewingKey.TextEncoding;
 		this.logger.WriteLine(actual);
 		Assert.Equal(expected, actual);
 
-		var decoded = IncomingViewingKey.FromEncoded(actual);
-		Assert.Equal(account.FullViewingKey.IncomingViewingKey, decoded);
+		Assert.True(IncomingViewingKey.TryDecode(actual, out DecodeError? decodeError, out string? errorMessage, out IncomingViewingKey? key));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.Equal(account.FullViewingKey.IncomingViewingKey, key);
 	}
 
 	[Fact]

--- a/test/Nerdbank.Zcash.Tests/Sapling/IncomingViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Sapling/IncomingViewingKeyTests.cs
@@ -9,6 +9,7 @@ namespace Sapling;
 public class IncomingViewingKeyTests : TestBase
 {
 	private readonly ITestOutputHelper logger;
+	private readonly IncomingViewingKey ivk = new Zip32HDWallet(Mnemonic, ZcashNetwork.MainNet).CreateSaplingAccount().IncomingViewingKey;
 
 	public IncomingViewingKeyTests(ITestOutputHelper logger)
 	{
@@ -50,5 +51,43 @@ public class IncomingViewingKeyTests : TestBase
 		Assert.False(account2.IncomingViewingKey.CheckReceiver(receiver.Value));
 		Assert.False(account2.IncomingViewingKey.TryGetDiversifierIndex(receiver.Value, out idx));
 		Assert.Null(idx);
+	}
+
+	[Fact]
+	public void TryDecode()
+	{
+		Assert.True(IncomingViewingKey.TryDecode(this.ivk.TextEncoding, out DecodeError? decodeError, out string? errorMessage, out IncomingViewingKey? imported));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.NotNull(imported);
+		Assert.Equal(this.ivk.TextEncoding, imported.TextEncoding);
+	}
+
+	[Fact]
+	public void TryDecode_ViaInterface()
+	{
+		Assert.True(TryDecodeViaInterface<IncomingViewingKey>(this.ivk.TextEncoding, out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? imported));
+		Assert.Null(decodeError);
+		Assert.Null(errorMessage);
+		Assert.NotNull(imported);
+		Assert.Equal(this.ivk.TextEncoding, imported.TextEncoding);
+	}
+
+	[Fact]
+	public void TryDecode_Fail()
+	{
+		Assert.False(IncomingViewingKey.TryDecode("fail", out DecodeError? decodeError, out string? errorMessage, out IncomingViewingKey? imported));
+		Assert.NotNull(decodeError);
+		Assert.NotNull(errorMessage);
+		Assert.Null(imported);
+	}
+
+	[Fact]
+	public void TryDecode_ViaInterface_Fail()
+	{
+		Assert.False(TryDecodeViaInterface<IncomingViewingKey>("fail", out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? imported));
+		Assert.NotNull(decodeError);
+		Assert.NotNull(errorMessage);
+		Assert.Null(imported);
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/SaplingAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/SaplingAddressTests.cs
@@ -19,16 +19,16 @@ public class SaplingAddressTests : TestBase
 	[Fact]
 	public void Network()
 	{
-		Assert.Equal(ZcashNetwork.MainNet, Assert.IsType<SaplingAddress>(ZcashAddress.Parse(ValidSaplingAddress)).Network);
+		Assert.Equal(ZcashNetwork.MainNet, Assert.IsType<SaplingAddress>(ZcashAddress.Decode(ValidSaplingAddress)).Network);
 	}
 
 	[Fact]
-	public void HasShieldedReceiver() => Assert.True(ZcashAddress.Parse(ValidSaplingAddress).HasShieldedReceiver);
+	public void HasShieldedReceiver() => Assert.True(ZcashAddress.Decode(ValidSaplingAddress).HasShieldedReceiver);
 
 	[Theory, MemberData(nameof(InvalidAddresses))]
-	public void TryParse_Invalid(string address)
+	public void TryDecode_Invalid(string address)
 	{
-		Assert.False(ZcashAddress.TryParse(address, out _));
+		Assert.False(ZcashAddress.TryDecode(address, out _, out _, out _));
 	}
 
 	[Fact]

--- a/test/Nerdbank.Zcash.Tests/SproutAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/SproutAddressTests.cs
@@ -14,22 +14,22 @@ public class SproutAddressTests : TestBase
 	[Fact]
 	public void Network()
 	{
-		Assert.Equal(ZcashNetwork.MainNet, Assert.IsType<SproutAddress>(ZcashAddress.Parse(ValidSproutAddress)).Network);
+		Assert.Equal(ZcashNetwork.MainNet, Assert.IsType<SproutAddress>(ZcashAddress.Decode(ValidSproutAddress)).Network);
 	}
 
 	[Fact]
-	public void HasShieldedReceiver() => Assert.True(ZcashAddress.Parse(ValidSproutAddress).HasShieldedReceiver);
+	public void HasShieldedReceiver() => Assert.True(ZcashAddress.Decode(ValidSproutAddress).HasShieldedReceiver);
 
 	[Theory, MemberData(nameof(InvalidAddresses))]
-	public void TryParse_Invalid(string address)
+	public void TryDecode_Invalid(string address)
 	{
-		Assert.False(ZcashAddress.TryParse(address, out _));
+		Assert.False(ZcashAddress.TryDecode(address, out _, out _, out _));
 	}
 
 	[Fact]
 	public void Ctor_Receiver()
 	{
-		SproutReceiver? receiver = ZcashAddress.Parse(ValidSproutAddress).GetPoolReceiver<SproutReceiver>();
+		SproutReceiver? receiver = ZcashAddress.Decode(ValidSproutAddress).GetPoolReceiver<SproutReceiver>();
 		Assert.NotNull(receiver);
 		SproutAddress addr = new(receiver.Value);
 		Assert.Equal(ZcashNetwork.MainNet, addr.Network);
@@ -40,7 +40,7 @@ public class SproutAddressTests : TestBase
 	[Fact]
 	public void Ctor_Receiver_TestNet()
 	{
-		SproutReceiver? receiver = ZcashAddress.Parse(ValidSproutAddress).GetPoolReceiver<SproutReceiver>();
+		SproutReceiver? receiver = ZcashAddress.Decode(ValidSproutAddress).GetPoolReceiver<SproutReceiver>();
 		Assert.NotNull(receiver);
 		SproutAddress addr = new(receiver.Value, ZcashNetwork.TestNet);
 		Assert.Equal(ZcashNetwork.TestNet, addr.Network);

--- a/test/Nerdbank.Zcash.Tests/TestBase.cs
+++ b/test/Nerdbank.Zcash.Tests/TestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 public abstract class TestBase
 {
@@ -52,4 +53,10 @@ public abstract class TestBase
 	/// per the policy set by <see cref="TimeoutTokenSource"/>.
 	/// </summary>
 	protected CancellationToken TimeoutToken => this.TimeoutTokenSource.Token;
+
+	protected static bool TryDecodeViaInterface<T>(string encoded, [NotNullWhen(false)] out DecodeError? decodeError, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out IKeyWithTextEncoding? key)
+		where T : IKeyWithTextEncoding
+	{
+		return T.TryDecode(encoded, out decodeError, out errorMessage, out key);
+	}
 }

--- a/test/Nerdbank.Zcash.Tests/TransparentAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentAddressTests.cs
@@ -5,7 +5,7 @@ using Microsoft;
 
 public class TransparentAddressTests : TestBase
 {
-	private static readonly TransparentAddress ParsedP2PKHAddress = (TransparentP2PKHAddress)ZcashAddress.Parse(ValidTransparentP2PKHAddress);
+	private static readonly TransparentAddress ParsedP2PKHAddress = (TransparentP2PKHAddress)ZcashAddress.Decode(ValidTransparentP2PKHAddress);
 
 	private readonly ITestOutputHelper logger;
 
@@ -25,17 +25,17 @@ public class TransparentAddressTests : TestBase
 	public void Network()
 	{
 		Assert.Equal(ZcashNetwork.MainNet, ParsedP2PKHAddress.Network);
-		Assert.Equal(ZcashNetwork.MainNet, Assert.IsAssignableFrom<TransparentAddress>(ZcashAddress.Parse(ValidTransparentP2SHAddress)).Network);
+		Assert.Equal(ZcashNetwork.MainNet, Assert.IsAssignableFrom<TransparentAddress>(ZcashAddress.Decode(ValidTransparentP2SHAddress)).Network);
 	}
 
 	[Theory, MemberData(nameof(InvalidAddresses))]
-	public void TryParse_Invalid(string address)
+	public void TryDecode_Invalid(string address)
 	{
-		Assert.False(ZcashAddress.TryParse(address, out _));
+		Assert.False(ZcashAddress.TryDecode(address, out _, out _, out _));
 	}
 
 	[Fact]
-	public void TryParse_BadNetwork()
+	public void TryDecode_BadNetwork()
 	{
 		// Manufacture a transparent address with a bad network header.
 		byte[] receiver = new byte[22];
@@ -46,16 +46,16 @@ public class TransparentAddressTests : TestBase
 		string addr = new(addrChars, 0, count);
 		Assumes.True(addr.StartsWith('t'));
 
-		Assert.False(ZcashAddress.TryParse(addr, out _));
+		Assert.False(ZcashAddress.TryDecode(addr, out _, out _, out _));
 	}
 
 	[Theory]
 	[InlineData("tdasgh2344235")]
 	[InlineData("tadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadada")]
 	[InlineData("tbalsdhfldsfhsdhfgdfgdf")]
-	public void TryParse_FuzzInputs_ShouldReturnFalse(string input)
+	public void TryDecode_FuzzInputs_ShouldReturnFalse(string input)
 	{
-		Assert.False(ZcashAddress.TryParse(input, out ZcashAddress? address, out ParseError? errorCode, out string? errorMessage));
+		Assert.False(ZcashAddress.TryDecode(input, out DecodeError? errorCode, out string? errorMessage, out ZcashAddress? address));
 		this.logger.WriteLine(errorMessage);
 
 		Assert.Null(address);

--- a/test/Nerdbank.Zcash.Tests/TransparentP2PKHAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2PKHAddressTests.cs
@@ -35,9 +35,9 @@ public class TransparentP2PKHAddressTests : TestBase
 	[Fact]
 	public void GetPoolReceiver()
 	{
-		Assert.NotNull(ZcashAddress.Parse(ValidTransparentP2PKHAddress).GetPoolReceiver<TransparentP2PKHReceiver>());
-		Assert.Null(ZcashAddress.Parse(ValidTransparentP2PKHAddress).GetPoolReceiver<TransparentP2SHReceiver>());
-		Assert.Null(ZcashAddress.Parse(ValidTransparentP2PKHAddress).GetPoolReceiver<SaplingReceiver>());
+		Assert.NotNull(ZcashAddress.Decode(ValidTransparentP2PKHAddress).GetPoolReceiver<TransparentP2PKHReceiver>());
+		Assert.Null(ZcashAddress.Decode(ValidTransparentP2PKHAddress).GetPoolReceiver<TransparentP2SHReceiver>());
+		Assert.Null(ZcashAddress.Decode(ValidTransparentP2PKHAddress).GetPoolReceiver<SaplingReceiver>());
 	}
 
 	[Fact]

--- a/test/Nerdbank.Zcash.Tests/TransparentP2SHAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2SHAddressTests.cs
@@ -25,8 +25,8 @@ public class TransparentP2SHAddressTests : TestBase
 	[Fact]
 	public void GetPoolReceiver()
 	{
-		Assert.NotNull(ZcashAddress.Parse(ValidTransparentP2SHAddress).GetPoolReceiver<TransparentP2SHReceiver>());
-		Assert.Null(ZcashAddress.Parse(ValidTransparentP2SHAddress).GetPoolReceiver<TransparentP2PKHReceiver>());
-		Assert.Null(ZcashAddress.Parse(ValidTransparentP2SHAddress).GetPoolReceiver<SaplingReceiver>());
+		Assert.NotNull(ZcashAddress.Decode(ValidTransparentP2SHAddress).GetPoolReceiver<TransparentP2SHReceiver>());
+		Assert.Null(ZcashAddress.Decode(ValidTransparentP2SHAddress).GetPoolReceiver<TransparentP2PKHReceiver>());
+		Assert.Null(ZcashAddress.Decode(ValidTransparentP2SHAddress).GetPoolReceiver<SaplingReceiver>());
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/UnifiedAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/UnifiedAddressTests.cs
@@ -19,32 +19,32 @@ public class UnifiedAddressTests : TestBase
 	[Fact]
 	public void Receivers_UnifiedMultiple()
 	{
-		UnifiedAddress addr = Assert.IsAssignableFrom<UnifiedAddress>(ZcashAddress.Parse(ValidUnifiedAddressOrchardSapling));
+		UnifiedAddress addr = Assert.IsAssignableFrom<UnifiedAddress>(ZcashAddress.Decode(ValidUnifiedAddressOrchardSapling));
 		Assert.Equal(
 			new[]
 			{
-				ZcashAddress.Parse(ValidUnifiedAddressOrchard),
-				ZcashAddress.Parse(ValidSaplingAddress),
+				ZcashAddress.Decode(ValidUnifiedAddressOrchard),
+				ZcashAddress.Decode(ValidSaplingAddress),
 			},
 			addr.Receivers);
 
-		addr = Assert.IsAssignableFrom<UnifiedAddress>(ZcashAddress.Parse(ValidUnifiedAddressOrchardSaplingTransparentP2PKH));
+		addr = Assert.IsAssignableFrom<UnifiedAddress>(ZcashAddress.Decode(ValidUnifiedAddressOrchardSaplingTransparentP2PKH));
 		Assert.Equal(
 			new[]
 			{
-				ZcashAddress.Parse(ValidUnifiedAddressOrchard),
-				ZcashAddress.Parse(ValidSaplingAddress),
-				ZcashAddress.Parse(ValidTransparentP2PKHAddress),
+				ZcashAddress.Decode(ValidUnifiedAddressOrchard),
+				ZcashAddress.Decode(ValidSaplingAddress),
+				ZcashAddress.Decode(ValidTransparentP2PKHAddress),
 			},
 			addr.Receivers);
 
-		addr = Assert.IsAssignableFrom<UnifiedAddress>(ZcashAddress.Parse(ValidUnifiedAddressOrchardSaplingTransparentP2SH));
+		addr = Assert.IsAssignableFrom<UnifiedAddress>(ZcashAddress.Decode(ValidUnifiedAddressOrchardSaplingTransparentP2SH));
 		Assert.Equal(
 			new[]
 			{
-				ZcashAddress.Parse(ValidUnifiedAddressOrchard),
-				ZcashAddress.Parse(ValidSaplingAddress),
-				ZcashAddress.Parse(ValidTransparentP2SHAddress),
+				ZcashAddress.Decode(ValidUnifiedAddressOrchard),
+				ZcashAddress.Decode(ValidSaplingAddress),
+				ZcashAddress.Decode(ValidTransparentP2SHAddress),
 			},
 			addr.Receivers);
 	}
@@ -52,7 +52,7 @@ public class UnifiedAddressTests : TestBase
 	[Fact]
 	public void GetPoolReceiver()
 	{
-		var ua = (UnifiedAddress)ZcashAddress.Parse(ValidUnifiedAddressOrchardSaplingTransparentP2PKH);
+		var ua = (UnifiedAddress)ZcashAddress.Decode(ValidUnifiedAddressOrchardSaplingTransparentP2PKH);
 		OrchardReceiver orchard = ua.GetPoolReceiver<OrchardReceiver>() ?? throw new Exception("Missing Orchard receiver");
 		SaplingReceiver sapling = ua.GetPoolReceiver<SaplingReceiver>() ?? throw new Exception("Missing Sapling receiver");
 		TransparentP2PKHReceiver p2pkh = ua.GetPoolReceiver<TransparentP2PKHReceiver>() ?? throw new Exception("Missing P2PKH receiver");
@@ -62,8 +62,8 @@ public class UnifiedAddressTests : TestBase
 	[Fact]
 	public void HasShieldedReceiver()
 	{
-		Assert.True(ZcashAddress.Parse(ValidUnifiedAddressOrchardSaplingTransparentP2PKH).HasShieldedReceiver);
-		Assert.True(ZcashAddress.Parse(ValidUnifiedAddressSapling).HasShieldedReceiver);
+		Assert.True(ZcashAddress.Decode(ValidUnifiedAddressOrchardSaplingTransparentP2PKH).HasShieldedReceiver);
+		Assert.True(ZcashAddress.Decode(ValidUnifiedAddressSapling).HasShieldedReceiver);
 	}
 
 	[Fact]
@@ -79,8 +79,8 @@ public class UnifiedAddressTests : TestBase
 		// Per the spec, sprout addresses are not allowed.
 		Assert.Throws<ArgumentException>(() => UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidSaplingAddress),
-			ZcashAddress.Parse(ValidSproutAddress),
+			ZcashAddress.Decode(ValidSaplingAddress),
+			ZcashAddress.Decode(ValidSproutAddress),
 		}));
 	}
 
@@ -90,9 +90,9 @@ public class UnifiedAddressTests : TestBase
 		// Per the spec, only one transparent address (of either type) is allowed in a UA.
 		Assert.Throws<ArgumentException>(() => UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidSaplingAddress),
-			ZcashAddress.Parse(ValidTransparentP2SHAddress),
-			ZcashAddress.Parse(ValidTransparentP2PKHAddress),
+			ZcashAddress.Decode(ValidSaplingAddress),
+			ZcashAddress.Decode(ValidTransparentP2SHAddress),
+			ZcashAddress.Decode(ValidTransparentP2PKHAddress),
 		}));
 	}
 
@@ -101,8 +101,8 @@ public class UnifiedAddressTests : TestBase
 	{
 		Assert.Throws<ArgumentException>(() => UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidSaplingAddress),
-			ZcashAddress.Parse(ValidSaplingAddress2),
+			ZcashAddress.Decode(ValidSaplingAddress),
+			ZcashAddress.Decode(ValidSaplingAddress2),
 		}));
 	}
 
@@ -114,8 +114,8 @@ public class UnifiedAddressTests : TestBase
 	{
 		Assert.Throws<ArgumentException>(() => UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidUnifiedAddressOrchardSapling),
-			ZcashAddress.Parse(ValidUnifiedAddressOrchardSaplingTransparentP2PKH),
+			ZcashAddress.Decode(ValidUnifiedAddressOrchardSapling),
+			ZcashAddress.Decode(ValidUnifiedAddressOrchardSaplingTransparentP2PKH),
 		}));
 	}
 
@@ -124,17 +124,17 @@ public class UnifiedAddressTests : TestBase
 	{
 		var addr = UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidUnifiedAddressOrchard),
-			ZcashAddress.Parse(ValidSaplingAddress),
-			ZcashAddress.Parse(ValidTransparentP2PKHAddress),
+			ZcashAddress.Decode(ValidUnifiedAddressOrchard),
+			ZcashAddress.Decode(ValidSaplingAddress),
+			ZcashAddress.Decode(ValidTransparentP2PKHAddress),
 		});
 		Assert.Equal(ValidUnifiedAddressOrchardSaplingTransparentP2PKH, addr.ToString());
 
 		addr = UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidUnifiedAddressOrchard),
-			ZcashAddress.Parse(ValidSaplingAddress),
-			ZcashAddress.Parse(ValidTransparentP2SHAddress),
+			ZcashAddress.Decode(ValidUnifiedAddressOrchard),
+			ZcashAddress.Decode(ValidSaplingAddress),
+			ZcashAddress.Decode(ValidTransparentP2SHAddress),
 		});
 		Assert.Equal(ValidUnifiedAddressOrchardSaplingTransparentP2SH, addr.ToString());
 	}
@@ -145,8 +145,8 @@ public class UnifiedAddressTests : TestBase
 		var addr = UnifiedAddress.Create(
 			new[]
 			{
-				ZcashAddress.Parse(ValidUnifiedAddressOrchardTestNet),
-				ZcashAddress.Parse(ValidSaplingAddressTestNet),
+				ZcashAddress.Decode(ValidUnifiedAddressOrchardTestNet),
+				ZcashAddress.Decode(ValidSaplingAddressTestNet),
 			});
 		this.logger.WriteLine(addr.Address);
 		Assert.Equal(ZcashNetwork.TestNet, addr.Network);
@@ -160,7 +160,7 @@ public class UnifiedAddressTests : TestBase
 		var addr = UnifiedAddress.Create(
 			new[]
 			{
-				ZcashAddress.Parse(ValidUnifiedAddressOrchardTestNet),
+				ZcashAddress.Decode(ValidUnifiedAddressOrchardTestNet),
 			});
 		this.logger.WriteLine(addr.Address);
 		Assert.Equal(ZcashNetwork.TestNet, addr.Network);
@@ -173,8 +173,8 @@ public class UnifiedAddressTests : TestBase
 	{
 		Assert.Throws<ArgumentException>(() => UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidSaplingAddressTestNet),
-			ZcashAddress.Parse(ValidUnifiedAddressOrchard),
+			ZcashAddress.Decode(ValidSaplingAddressTestNet),
+			ZcashAddress.Decode(ValidUnifiedAddressOrchard),
 		}));
 	}
 
@@ -183,7 +183,7 @@ public class UnifiedAddressTests : TestBase
 	{
 		var addr = UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidUnifiedAddressOrchard),
+			ZcashAddress.Decode(ValidUnifiedAddressOrchard),
 		});
 		this.logger.WriteLine(addr.Address);
 		Assert.Equal(ValidUnifiedAddressOrchard, addr.ToString());
@@ -194,7 +194,7 @@ public class UnifiedAddressTests : TestBase
 	{
 		var addr = UnifiedAddress.Create(new[]
 		{
-			ZcashAddress.Parse(ValidSaplingAddress),
+			ZcashAddress.Decode(ValidSaplingAddress),
 		});
 		this.logger.WriteLine(addr.Address);
 		Assert.Equal(ZcashNetwork.MainNet, addr.Network);
@@ -207,7 +207,7 @@ public class UnifiedAddressTests : TestBase
 		var addr = UnifiedAddress.Create(
 			new[]
 			{
-				ZcashAddress.Parse(ValidSaplingAddressTestNet),
+				ZcashAddress.Decode(ValidSaplingAddressTestNet),
 			});
 		this.logger.WriteLine(addr.Address);
 		Assert.Equal(ZcashNetwork.TestNet, addr.Network);
@@ -218,13 +218,13 @@ public class UnifiedAddressTests : TestBase
 	[Fact]
 	public void Network_AfterParse()
 	{
-		Assert.Equal(ZcashNetwork.MainNet, ZcashAddress.Parse(ValidUnifiedAddressSapling).Network);
-		Assert.Equal(ZcashNetwork.TestNet, ZcashAddress.Parse(ValidUnifiedAddressSaplingTestNet).Network);
+		Assert.Equal(ZcashNetwork.MainNet, ZcashAddress.Decode(ValidUnifiedAddressSapling).Network);
+		Assert.Equal(ZcashNetwork.TestNet, ZcashAddress.Decode(ValidUnifiedAddressSaplingTestNet).Network);
 	}
 
 	[Theory, MemberData(nameof(InvalidAddresses))]
-	public void TryParse_Invalid(string address)
+	public void TryDecode_Invalid(string address)
 	{
-		Assert.False(ZcashAddress.TryParse(address, out _));
+		Assert.False(ZcashAddress.TryDecode(address, out _, out _, out _));
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/UnifiedViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/UnifiedViewingKeyTests.cs
@@ -377,6 +377,26 @@ public class UnifiedViewingKeyTests : TestBase
 	}
 
 	[Fact]
+	public void TryDecode()
+	{
+		Assert.True(TryDecodeViaInterface<UnifiedViewingKey>("uview1tz7evwpdc274ekw8a7pej527wpxmchsv0hj7g65fhjgpsvzjzc3qhe79qea74c7repnc6mya6wdkawl6chk0vrx4u9dxfwhd9kl9l8k48qvy7tjtuxc4wzc0ety3t0r4p9mz88w2736m4l9r7d7t8hhj92wdxcgaukqkxmnchpn45zn5pwdmd99q6msfv7dglgqpkq95rgglsmklr7quc27xhy03fs2nha4xuufzns3glh4560tccrm739pqh6sfs33m8d50gyv5jshyra9uwktf62sdxhrjmtprse2r7sfq58mj3kv6tmh4f4xk4qfspe5qwcc3rxhp4ef2j0n22kg8fy0htd5q7umrrquek50g4tfx8vhyklphr2lg2nzqfnc6sxsp0k23z", out DecodeError? decodeError, out string? errorMessage, out IKeyWithTextEncoding? key));
+		UnifiedViewingKey uvk = (UnifiedViewingKey)key;
+
+		SaplingFVK? sapling = uvk.GetViewingKey<SaplingFVK>();
+		Assert.NotNull(sapling);
+		Assert.NotNull(sapling.IncomingViewingKey);
+		Assert.Equal(
+			"zs1duqpcc2ql7zfjttdm2gpawe8t5ecek5k834u9vdg4mqhw7j8j39sgjy8xguvk2semyd4ujeyj28",
+			sapling.IncomingViewingKey.DefaultAddress);
+
+		OrchardFVK? orchard = uvk.GetViewingKey<OrchardFVK>();
+		Assert.NotNull(orchard);
+		Assert.Equal(
+			"u1zpfqm4r0cc5ttvt4mft6nvyqe3uwsdcgx65s44sd3ar42rnkz7v9az0ez7dpyxvjcyj9x0sd89yy7635vn8fplwvg6vn4tr6wqpyxqaw",
+			orchard.IncomingViewingKey.DefaultAddress);
+	}
+
+	[Fact]
 	public void Create_FVK_RetainsViewingKeys()
 	{
 		Zip32HDWallet wallet = new(Mnemonic, ZcashNetwork.MainNet);

--- a/test/Nerdbank.Zcash.Tests/UnifiedViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/UnifiedViewingKeyTests.cs
@@ -74,8 +74,8 @@ public class UnifiedViewingKeyTests : TestBase
 		OrchardSK orchard = wallet.CreateOrchardAccount(0);
 		SaplingSK sapling = wallet.CreateSaplingAccount(0);
 		UnifiedViewingKey.Incoming uivk = UnifiedViewingKey.Incoming.Create(orchard.FullViewingKey, sapling.IncomingViewingKey);
-		this.logger.WriteLine(uivk.ViewingKey);
-		Assert.StartsWith("uivktest1", uivk.ViewingKey);
+		this.logger.WriteLine(uivk.TextEncoding);
+		Assert.StartsWith("uivktest1", uivk.TextEncoding);
 	}
 
 	[Fact]
@@ -84,7 +84,7 @@ public class UnifiedViewingKeyTests : TestBase
 		Zip32HDWallet wallet = new(Mnemonic, ZcashNetwork.MainNet);
 		OrchardSK orchard = wallet.CreateOrchardAccount(0);
 		UnifiedViewingKey uvk = UnifiedViewingKey.Full.Create(orchard.FullViewingKey);
-		Assert.Equal(uvk.ViewingKey, uvk.ToString());
+		Assert.Equal(uvk.TextEncoding, uvk.ToString());
 	}
 
 	[Fact]
@@ -93,7 +93,7 @@ public class UnifiedViewingKeyTests : TestBase
 		Zip32HDWallet wallet = new(Mnemonic, ZcashNetwork.MainNet);
 		OrchardSK orchard = wallet.CreateOrchardAccount(0);
 		UnifiedViewingKey uvk = UnifiedViewingKey.Incoming.Create(orchard.IncomingViewingKey);
-		Assert.Equal(uvk.ViewingKey, uvk.ToString());
+		Assert.Equal(uvk.TextEncoding, uvk.ToString());
 	}
 
 	[Fact]
@@ -103,7 +103,7 @@ public class UnifiedViewingKeyTests : TestBase
 		OrchardSK orchard = wallet.CreateOrchardAccount(0);
 		UnifiedViewingKey.Full uvk = UnifiedViewingKey.Full.Create(orchard.FullViewingKey);
 		string uvkString = uvk;
-		Assert.Equal(uvk.ViewingKey, uvkString);
+		Assert.Equal(uvk.TextEncoding, uvkString);
 	}
 
 	[Fact]
@@ -113,7 +113,7 @@ public class UnifiedViewingKeyTests : TestBase
 		OrchardSK orchard = wallet.CreateOrchardAccount(0);
 		UnifiedViewingKey.Incoming uvk = UnifiedViewingKey.Incoming.Create(orchard.IncomingViewingKey);
 		string uvkString = uvk;
-		Assert.Equal(uvk.ViewingKey, uvkString);
+		Assert.Equal(uvk.TextEncoding, uvkString);
 	}
 
 	[Fact]
@@ -125,7 +125,7 @@ public class UnifiedViewingKeyTests : TestBase
 
 		Assert.Equal(
 			"uview12z0pgg2u7q5ky5wzas8mmgcs4zy8cmdyt62tn3ecpdurnqqnlldx6j73600qe4xkz7jp4w37elr2d48jm5ktuvlm5x8z5ke6cg3x8m6sk5sruh4xnjk93h86fls0uyhhtaj8vu0mw0t7cr74vc8ra2360yhamnskk7a7ahsasndmagsmuhs27lqdyjsz9",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	[Fact]
@@ -137,7 +137,7 @@ public class UnifiedViewingKeyTests : TestBase
 
 		Assert.Equal(
 			"uivk1zz6k7d37rldq7mk0n4uegyvesggreucz8h48nnrvlzznhvv3kqm4zp7wngksclaptu8hfqc6l57takh5x6jypygqp5m7d36gmxlxakgzqkp3luqrdgnk97k556wezjydjkmqkvkvf6",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	[Fact]
@@ -149,7 +149,7 @@ public class UnifiedViewingKeyTests : TestBase
 
 		Assert.Equal(
 			"uview17x4ug5kp5shmrywnsadcce6dmyj54ey9hgu4yek25zfw5vnhrghectdsdgsgc099jj99amrxkl5afvyv50jxpwg3u53rq4hzhtln8gurtu5vey602wp0q6xcyxnjtat0a5hn4z82am7fygd42u4h3n27ndtpkx9w6p8nv20k7f5swak7g4wvhte39sasxm9rxea3y7q3c537csxlut9jaf8g3j3ddl02x4j0j7zg0qglvx55",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	[Fact]
@@ -161,7 +161,7 @@ public class UnifiedViewingKeyTests : TestBase
 
 		Assert.Equal(
 			"uivk1fahcymtzgy7kza5nvvq9s0wjxsgjhwt5aunczjeg2sszfrutf0gdrfue9en54ecmlzfxr7hsfwyaqzygzf8f35ng6za3jzxfceh2t093asl04t299wca03ezeuchn4h2cf5s66zdzr",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	[Fact]
@@ -175,7 +175,7 @@ public class UnifiedViewingKeyTests : TestBase
 		// This expected value came from YWallet when generated with the test seed phrase.
 		Assert.Equal(
 			"uview1tz7evwpdc274ekw8a7pej527wpxmchsv0hj7g65fhjgpsvzjzc3qhe79qea74c7repnc6mya6wdkawl6chk0vrx4u9dxfwhd9kl9l8k48qvy7tjtuxc4wzc0ety3t0r4p9mz88w2736m4l9r7d7t8hhj92wdxcgaukqkxmnchpn45zn5pwdmd99q6msfv7dglgqpkq95rgglsmklr7quc27xhy03fs2nha4xuufzns3glh4560tccrm739pqh6sfs33m8d50gyv5jshyra9uwktf62sdxhrjmtprse2r7sfq58mj3kv6tmh4f4xk4qfspe5qwcc3rxhp4ef2j0n22kg8fy0htd5q7umrrquek50g4tfx8vhyklphr2lg2nzqfnc6sxsp0k23z",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	[Fact]
@@ -188,7 +188,7 @@ public class UnifiedViewingKeyTests : TestBase
 
 		Assert.Equal(
 			"uivk14pdvka3fgede8n5atxw3rq5h55w4qqyte3n8zkzhh8m92qju0kewjz3jzklnx99tu6u9lwye2a4gvks66sdkzrd2q67zqn7lwfejvqh9g32dad8mqy2hx7ug9ak6qryuq8u055a090s9mwaw7l86awhnrqkkgu4u8updz2rvuqn08x9efhtwmknl327a4s3akm2mv9qe2h9j788zmptyxsctmthdw8gngd2svmsex548s97ypjg",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	[Fact]
@@ -201,7 +201,7 @@ public class UnifiedViewingKeyTests : TestBase
 		this.logger.WriteLine(uvk);
 		Assert.Equal(
 			"uview1ntk3zd44nje0tz4x6ml8vxxse88dnsts9c3mdppgu3qk8gny27qrvjk38y9htmv0f5my8qp0nwpcepdpmqeat7gg9kux8jtkzl7nap73sptf4vcg03vgj94qd9kafm2q2mss69kpqy2",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	[Fact]
@@ -214,7 +214,7 @@ public class UnifiedViewingKeyTests : TestBase
 		this.logger.WriteLine(uvk);
 		Assert.Equal(
 			"uivk1rc6aa5kgpfgltsd2ds9gxggs3rpfayed6rr8mwnjk3hces69cgdv7p5nqvfe95fwy7kdfvs58z7er8kyyznezgnaky8jk9tx57zk4qzudm06tq9pglzfja4phcs7mu407m595ucetr2",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	[Fact]
@@ -228,7 +228,7 @@ public class UnifiedViewingKeyTests : TestBase
 
 		Assert.Equal(
 			"uview1tz7evwpdc274ekw8a7pej527wpxmchsv0hj7g65fhjgpsvzjzc3qhe79qea74c7repnc6mya6wdkawl6chk0vrx4u9dxfwhd9kl9l8k48qvy7tjtuxc4wzc0ety3t0r4p9mz88w2736m4l9r7d7t8hhj92wdxcgaukqkxmnchpn45zn5pwdmd99q6msfv7dglgqpkq95rgglsmklr7quc27xhy03fs2nha4xuufzns3glh4560tccrm739pqh6sfs33m8d50gyv5jshyra9uwktf62sdxhrjmtprse2r7sfq58mj3kv6tmh4f4xk4qfspe5qwcc3rxhp4ef2j0n22kg8fy0htd5q7umrrquek50g4tfx8vhyklphr2lg2nzqfnc6sxsp0k23z",
-			uvk.ViewingKey);
+			uvk.TextEncoding);
 	}
 
 	/// <summary>
@@ -306,22 +306,22 @@ public class UnifiedViewingKeyTests : TestBase
 	[Theory]
 	[InlineData("abc")]
 	[InlineData("")]
-	public void TryParse_BadInputs(string key)
+	public void TryDecode_BadInputs(string key)
 	{
-		Assert.False(UnifiedViewingKey.TryParse(key, out UnifiedViewingKey? result));
+		Assert.False(UnifiedViewingKey.TryDecode(key, out _, out _, out UnifiedViewingKey? result));
 		Assert.Null(result);
 
-		InvalidKeyException ex = Assert.Throws<InvalidKeyException>(() => UnifiedViewingKey.Parse(key));
+		InvalidKeyException ex = Assert.Throws<InvalidKeyException>(() => UnifiedViewingKey.Decode(key));
 		this.logger.WriteLine(ex.Message);
 	}
 
 	[Fact]
-	public void TryParse_Null()
+	public void TryDecode_Null()
 	{
 		UnifiedViewingKey? result = null;
-		Assert.Throws<ArgumentNullException>(() => UnifiedViewingKey.TryParse(null!, out result));
+		Assert.Throws<ArgumentNullException>(() => UnifiedViewingKey.TryDecode(null!, out _, out _, out result));
 		Assert.Null(result);
-		Assert.Throws<ArgumentNullException>(() => UnifiedViewingKey.Parse(null!));
+		Assert.Throws<ArgumentNullException>(() => UnifiedViewingKey.Decode(null!));
 	}
 
 	[Theory, PairwiseData]
@@ -358,9 +358,9 @@ public class UnifiedViewingKeyTests : TestBase
 	}
 
 	[Fact]
-	public void Parse_GetViewingKey()
+	public void Decode_GetViewingKey()
 	{
-		UnifiedViewingKey uvk = UnifiedViewingKey.Parse("uview1tz7evwpdc274ekw8a7pej527wpxmchsv0hj7g65fhjgpsvzjzc3qhe79qea74c7repnc6mya6wdkawl6chk0vrx4u9dxfwhd9kl9l8k48qvy7tjtuxc4wzc0ety3t0r4p9mz88w2736m4l9r7d7t8hhj92wdxcgaukqkxmnchpn45zn5pwdmd99q6msfv7dglgqpkq95rgglsmklr7quc27xhy03fs2nha4xuufzns3glh4560tccrm739pqh6sfs33m8d50gyv5jshyra9uwktf62sdxhrjmtprse2r7sfq58mj3kv6tmh4f4xk4qfspe5qwcc3rxhp4ef2j0n22kg8fy0htd5q7umrrquek50g4tfx8vhyklphr2lg2nzqfnc6sxsp0k23z");
+		UnifiedViewingKey uvk = UnifiedViewingKey.Decode("uview1tz7evwpdc274ekw8a7pej527wpxmchsv0hj7g65fhjgpsvzjzc3qhe79qea74c7repnc6mya6wdkawl6chk0vrx4u9dxfwhd9kl9l8k48qvy7tjtuxc4wzc0ety3t0r4p9mz88w2736m4l9r7d7t8hhj92wdxcgaukqkxmnchpn45zn5pwdmd99q6msfv7dglgqpkq95rgglsmklr7quc27xhy03fs2nha4xuufzns3glh4560tccrm739pqh6sfs33m8d50gyv5jshyra9uwktf62sdxhrjmtprse2r7sfq58mj3kv6tmh4f4xk4qfspe5qwcc3rxhp4ef2j0n22kg8fy0htd5q7umrrquek50g4tfx8vhyklphr2lg2nzqfnc6sxsp0k23z");
 
 		SaplingFVK? sapling = uvk.GetViewingKey<SaplingFVK>();
 		Assert.NotNull(sapling);
@@ -427,11 +427,11 @@ public class UnifiedViewingKeyTests : TestBase
 
 	private static void AssertNoOutgoingKey(UnifiedViewingKey uivk)
 	{
-		Assert.StartsWith("uivk1", uivk.ViewingKey);
+		Assert.StartsWith("uivk1", uivk.TextEncoding);
 		Assert.NotNull(uivk.GetViewingKey<IIncomingViewingKey>());
 		Assert.Null(uivk.GetViewingKey<IFullViewingKey>());
 
-		UnifiedViewingKey parsed = UnifiedViewingKey.Parse(uivk);
+		UnifiedViewingKey parsed = UnifiedViewingKey.Decode(uivk);
 		Assert.NotNull(parsed.GetViewingKey<IIncomingViewingKey>());
 		Assert.Null(parsed.GetViewingKey<IFullViewingKey>());
 	}
@@ -441,17 +441,17 @@ public class UnifiedViewingKeyTests : TestBase
 		Assert.NotNull(uvk.GetViewingKey<IIncomingViewingKey>());
 		Assert.Null(uvk.GetViewingKey<ISpendingKey>());
 
-		UnifiedViewingKey parsed = UnifiedViewingKey.Parse(uvk);
+		UnifiedViewingKey parsed = UnifiedViewingKey.Decode(uvk);
 		Assert.NotNull(parsed.GetViewingKey<IIncomingViewingKey>());
 		Assert.Null(parsed.GetViewingKey<ISpendingKey>());
 	}
 
 	private static void AssertRoundtrip(UnifiedViewingKey uvk)
 	{
-		UnifiedViewingKey reparsed = UnifiedViewingKey.Parse(uvk);
+		UnifiedViewingKey reparsed = UnifiedViewingKey.Decode(uvk);
 		Assert.Equal(uvk.Network, reparsed.Network);
 		Assert.Equal(uvk.GetType(), reparsed.GetType());
-		Assert.Equal(uvk.ViewingKey, reparsed.ViewingKey);
+		Assert.Equal(uvk.TextEncoding, reparsed.TextEncoding);
 
 		Assert.True(uvk.Equals(reparsed));
 	}

--- a/test/Nerdbank.Zcash.Tests/ZcashAccountTests.cs
+++ b/test/Nerdbank.Zcash.Tests/ZcashAccountTests.cs
@@ -137,4 +137,148 @@ public class ZcashAccountTests : TestBase
 		// Transparent only accounts have no diversifiable keys.
 		Assert.False(new ZcashAccount(UnifiedViewingKey.Incoming.Create(DefaultAccount.IncomingViewing.Transparent!)).HasDiversifiableKeys);
 	}
+
+	[Fact]
+	public void TryImportAccount_InvalidKey()
+	{
+		Assert.False(ZcashAccount.TryImportAccount("abc", out ZcashAccount? account));
+		Assert.Null(account);
+	}
+
+	[Fact]
+	public void TryImportAccount_Spending_Orchard()
+	{
+		ZcashAccount account = this.ImportAccount(DefaultAccount.Spending!.Orchard!.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.NotNull(account.Spending);
+		Assert.NotNull(account.Spending.Orchard);
+		Assert.Null(account.Spending.Sapling);
+
+		Assert.NotNull(account.FullViewing);
+		Assert.NotNull(account.FullViewing.Orchard);
+
+		Assert.NotNull(account.IncomingViewing.Orchard);
+	}
+
+	[Fact]
+	public void TryImportAccount_UVK()
+	{
+		ZcashAccount account = this.ImportAccount(DefaultAccount.FullViewing!.UnifiedKey.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.Null(account.Spending);
+
+		Assert.NotNull(account.FullViewing);
+		Assert.NotNull(account.FullViewing.Transparent);
+		Assert.NotNull(account.FullViewing.Sapling);
+		Assert.NotNull(account.FullViewing.Orchard);
+
+		Assert.NotNull(account.IncomingViewing);
+		Assert.NotNull(account.IncomingViewing.Transparent);
+		Assert.NotNull(account.IncomingViewing.Sapling);
+		Assert.NotNull(account.IncomingViewing.Orchard);
+	}
+
+	[Fact]
+	public void TryImportAccount_FullViewing_Orchard()
+	{
+		ZcashAccount account = this.ImportAccount(DefaultAccount.FullViewing!.Orchard!.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.Null(account.Spending);
+
+		Assert.NotNull(account.FullViewing);
+		Assert.NotNull(account.FullViewing.Orchard);
+		Assert.Null(account.FullViewing.Transparent);
+		Assert.Null(account.FullViewing.Sapling);
+
+		Assert.NotNull(account.IncomingViewing);
+		Assert.NotNull(account.IncomingViewing.Orchard);
+		Assert.Null(account.IncomingViewing.Transparent);
+		Assert.Null(account.IncomingViewing.Sapling);
+	}
+
+	[Fact]
+	public void TryImportAccount_FullViewing_Sapling()
+	{
+		ZcashAccount account = this.ImportAccount(Zip32.CreateSaplingAccount(0).ExtendedFullViewingKey.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.Null(account.Spending);
+
+		Assert.NotNull(account.FullViewing);
+		Assert.Null(account.FullViewing.Orchard);
+		Assert.NotNull(account.FullViewing.Sapling);
+		Assert.Null(account.FullViewing.Transparent);
+
+		Assert.NotNull(account.IncomingViewing);
+		Assert.Null(account.IncomingViewing.Orchard);
+		Assert.NotNull(account.IncomingViewing.Sapling);
+		Assert.Null(account.IncomingViewing.Transparent);
+	}
+
+	[Fact]
+	public void TryImportAccount_Spending_Transparent()
+	{
+		ZcashAccount account = this.ImportAccount(DefaultAccount.Spending!.Transparent!.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.NotNull(account.Spending);
+		Assert.Null(account.Spending.Orchard);
+		Assert.Null(account.Spending.Sapling);
+		Assert.NotNull(account.Spending.Transparent);
+
+		Assert.NotNull(account.FullViewing);
+		Assert.Null(account.FullViewing.Orchard);
+		Assert.Null(account.FullViewing.Sapling);
+		Assert.NotNull(account.FullViewing.Transparent);
+
+		Assert.NotNull(account.IncomingViewing);
+		Assert.Null(account.IncomingViewing.Orchard);
+		Assert.Null(account.IncomingViewing.Sapling);
+		Assert.NotNull(account.IncomingViewing.Transparent);
+	}
+
+	[Fact]
+	public void TryImportAccount_FullViewing_Transparent()
+	{
+		ZcashAccount account = this.ImportAccount(DefaultAccount.FullViewing!.Transparent!.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.Null(account.Spending);
+
+		Assert.NotNull(account.FullViewing);
+		Assert.Null(account.FullViewing.Orchard);
+		Assert.Null(account.FullViewing.Sapling);
+		Assert.NotNull(account.FullViewing.Transparent);
+
+		Assert.NotNull(account.IncomingViewing);
+		Assert.Null(account.IncomingViewing.Orchard);
+		Assert.Null(account.IncomingViewing.Sapling);
+		Assert.NotNull(account.IncomingViewing.Transparent);
+	}
+
+	[Fact]
+	public void TryImportAccount_IncomingViewing_Orchard()
+	{
+		ZcashAccount account = this.ImportAccount(DefaultAccount.IncomingViewing.Orchard!.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.Null(account.Spending);
+
+		Assert.Null(account.FullViewing);
+
+		Assert.NotNull(account.IncomingViewing);
+		Assert.NotNull(account.IncomingViewing.Orchard);
+		Assert.Null(account.IncomingViewing.Transparent);
+		Assert.Null(account.IncomingViewing.Sapling);
+	}
+
+	private ZcashAccount ImportAccount(string encoded)
+	{
+		this.logger.WriteLine(encoded);
+		Assert.True(ZcashAccount.TryImportAccount(encoded, out ZcashAccount? account));
+		return account;
+	}
 }

--- a/test/Nerdbank.Zcash.Tests/ZcashAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/ZcashAddressTests.cs
@@ -20,41 +20,41 @@ public class ZcashAddressTests : TestBase
 	};
 
 	[Theory, MemberData(nameof(ValidAddresses))]
-	public void Parse_Valid(string address)
+	public void Decode_Valid(string address)
 	{
-		var addr = ZcashAddress.Parse(address);
+		var addr = ZcashAddress.Decode(address);
 		Assert.Equal(address, addr.ToString());
 	}
 
 	[Theory, MemberData(nameof(ValidAddresses))]
-	public void TryParse_Valid(string address)
+	public void TryDecode_Valid(string address)
 	{
-		Assert.True(ZcashAddress.TryParse(address, out ZcashAddress? addr));
+		Assert.True(ZcashAddress.TryDecode(address, out _, out _, out ZcashAddress? addr));
 		Assert.Equal(address, addr.ToString());
 	}
 
 	[Theory, MemberData(nameof(InvalidAddresses))]
 	public void Parse_Invalid(string address)
 	{
-		Assert.Throws<InvalidAddressException>(() => ZcashAddress.Parse(address));
+		Assert.Throws<InvalidAddressException>(() => ZcashAddress.Decode(address));
 	}
 
 	[Theory, MemberData(nameof(InvalidAddresses))]
-	public void TryParse_Invalid(string address)
+	public void TryDecode_Invalid(string address)
 	{
-		Assert.False(ZcashAddress.TryParse(address, out _));
+		Assert.False(ZcashAddress.TryDecode(address, out _, out _, out _));
 	}
 
 	[Fact]
 	public void Parse_Null()
 	{
-		Assert.Throws<ArgumentNullException>(() => ZcashAddress.Parse(null!));
+		Assert.Throws<ArgumentNullException>(() => ZcashAddress.Decode(null!));
 	}
 
 	[Fact]
-	public void TryParse_Null()
+	public void TryDecode_Null()
 	{
-		Assert.Throws<ArgumentNullException>(() => ZcashAddress.TryParse(null!, out _));
+		Assert.Throws<ArgumentNullException>(() => ZcashAddress.TryDecode(null!, out _, out _, out _));
 	}
 
 	[Theory]
@@ -65,16 +65,16 @@ public class ZcashAddressTests : TestBase
 	[InlineData(ValidSproutAddress, typeof(SproutAddress))]
 	[InlineData(ValidTransparentP2PKHAddress, typeof(TransparentP2PKHAddress))]
 	[InlineData(ValidTransparentP2SHAddress, typeof(TransparentP2SHAddress))]
-	public void Parse_ReturnsAppropriateType(string address, Type expectedKind)
+	public void Decode_ReturnsAppropriateType(string address, Type expectedKind)
 	{
-		var addr = ZcashAddress.Parse(address);
+		var addr = ZcashAddress.Decode(address);
 		Assert.IsAssignableFrom(expectedKind, addr);
 	}
 
 	[Fact]
 	public void ImplicitlyCastableToString()
 	{
-		var addr = ZcashAddress.Parse(ValidTransparentP2PKHAddress);
+		var addr = ZcashAddress.Decode(ValidTransparentP2PKHAddress);
 		string str = addr.Address;
 		Assert.Equal(ValidTransparentP2PKHAddress, str);
 	}
@@ -82,9 +82,9 @@ public class ZcashAddressTests : TestBase
 	[Fact]
 	public void Equality()
 	{
-		var addr1a = ZcashAddress.Parse(ValidTransparentP2PKHAddress);
-		var addr1b = ZcashAddress.Parse(ValidTransparentP2PKHAddress);
-		var addr2 = ZcashAddress.Parse(ValidTransparentP2SHAddress);
+		var addr1a = ZcashAddress.Decode(ValidTransparentP2PKHAddress);
+		var addr1b = ZcashAddress.Decode(ValidTransparentP2PKHAddress);
+		var addr2 = ZcashAddress.Decode(ValidTransparentP2SHAddress);
 		Assert.Equal(addr1a, addr1b);
 		Assert.NotEqual(addr1a, addr2);
 	}
@@ -92,9 +92,9 @@ public class ZcashAddressTests : TestBase
 	[Fact]
 	public void HashCodes()
 	{
-		var addr1a = ZcashAddress.Parse(ValidTransparentP2PKHAddress);
-		var addr1b = ZcashAddress.Parse(ValidTransparentP2PKHAddress);
-		var addr2 = ZcashAddress.Parse(ValidTransparentP2SHAddress);
+		var addr1a = ZcashAddress.Decode(ValidTransparentP2PKHAddress);
+		var addr1b = ZcashAddress.Decode(ValidTransparentP2PKHAddress);
+		var addr2 = ZcashAddress.Decode(ValidTransparentP2SHAddress);
 		Assert.Equal(addr1a.GetHashCode(), addr1b.GetHashCode());
 		Assert.NotEqual(addr1a.GetHashCode(), addr2.GetHashCode());
 	}
@@ -102,7 +102,7 @@ public class ZcashAddressTests : TestBase
 	[Fact]
 	public void ImplicitCast()
 	{
-		string address = ZcashAddress.Parse(ValidTransparentP2SHAddress);
+		string address = ZcashAddress.Decode(ValidTransparentP2SHAddress);
 		Assert.Equal(ValidTransparentP2SHAddress, address);
 	}
 

--- a/test/Nerdbank.Zcash.Tests/ZcashUtilitiesTests.cs
+++ b/test/Nerdbank.Zcash.Tests/ZcashUtilitiesTests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Nerdbank.Cryptocurrencies.Exchanges;
+
+public class ZcashUtilitiesTests : TestBase
+{
+	private readonly ITestOutputHelper logger;
+
+	public ZcashUtilitiesTests(ITestOutputHelper logger)
+	{
+		this.logger = logger;
+	}
+
+	[Fact]
+	public void GetTickerName()
+	{
+		Assert.Equal("ZEC", ZcashUtilities.GetTickerName(ZcashNetwork.MainNet));
+		Assert.Equal("TAZ", ZcashUtilities.GetTickerName(ZcashNetwork.TestNet));
+	}
+
+	[Fact]
+	public void AsSecurity_MainNet()
+	{
+		Assert.Equal(Security.ZEC, ZcashUtilities.AsSecurity(ZcashNetwork.MainNet));
+	}
+
+	[Fact]
+	public void AsSecurity_TestNet()
+	{
+		Security actual = ZcashUtilities.AsSecurity(ZcashNetwork.TestNet);
+		Assert.Equal("TAZ", actual.TickerSymbol);
+		Assert.Equal(8, actual.Precision);
+		Assert.Equal("Zcash (testnet)", actual.Name);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_UnifiedFullViewingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseKey(network, a => a.FullViewing!.UnifiedKey);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_UnifiedIncomingViewingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseKey(network, a => a.IncomingViewing.UnifiedKey);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_Orchard_SpendingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseKey(network, a => a.Spending!.Orchard!);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_Orchard_FullViewingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseUnifiedKey(network, a => a.FullViewing!.Orchard!);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_Orchard_IncomingViewingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseUnifiedKey(network, a => a.IncomingViewing.Orchard!);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_Sapling_SpendingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseKey(network, a => a.Spending!.Sapling!);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_Sapling_FullViewingKey(ZcashNetwork network)
+	{
+		// We can't round-trip a ZcashAccount.FullViewing.Sapling key because
+		// a Sapling DiversifiableFullViewingKey has no defined text encoding.
+		// Only FVKs (which like the diversifier key) and extended fvk's have
+		// defined text encodings.
+		Zip32HDWallet.Sapling.ExtendedSpendingKey saplingESK = Zip32HDWallet.Sapling.Create(Bip39Mnemonic.Create(32), network);
+		Zip32HDWallet.Sapling.ExtendedFullViewingKey saplingEFVK = saplingESK.ExtendedFullViewingKey;
+		this.Assert_KeyRoundTrip(saplingEFVK);
+	}
+
+	[Fact]
+	public void TryParseKey_InvalidKey()
+	{
+		Assert.False(ZcashUtilities.TryParseKey("abc", out IKeyWithTextEncoding? key));
+		Assert.Null(key);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_Sapling_IncomingViewingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseKey(network, a => a.IncomingViewing.Sapling!);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_Transparent_SpendingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseKey(network, a => a.Spending!.Transparent!);
+	}
+
+	[Theory, PairwiseData]
+	public void TryParseKey_Transparent_FullViewingKey(ZcashNetwork network)
+	{
+		this.Assert_TryParseKey(network, a => a.FullViewing!.Transparent!);
+	}
+
+	private void Assert_TryParseKey<TKey>(ZcashNetwork network, Func<ZcashAccount, TKey> keyExtractor)
+		where TKey : class, IKeyWithTextEncoding
+	{
+		ZcashAccount account = new(new Zip32HDWallet(Bip39Mnemonic.Create(32), network));
+
+		TKey original = keyExtractor(account);
+		this.Assert_KeyRoundTrip(original);
+	}
+
+	private void Assert_KeyRoundTrip<TKey>(TKey original)
+		where TKey : class, IKeyWithTextEncoding
+	{
+		string encoded = original.TextEncoding;
+		this.logger.WriteLine(encoded);
+		Assert.True(ZcashUtilities.TryParseKey(encoded, out IKeyWithTextEncoding? parsed));
+		Assert.IsType<TKey>(parsed);
+		Assert.Equal(encoded, parsed.TextEncoding);
+	}
+
+	private void Assert_TryParseUnifiedKey<TKey>(ZcashNetwork network, Func<ZcashAccount, TKey> keyExtractor)
+		where TKey : class, IKeyWithTextEncoding, IIncomingViewingKey
+	{
+		ZcashAccount account = new(new Zip32HDWallet(Bip39Mnemonic.Create(32), network));
+
+		TKey original = keyExtractor(account);
+		string encoded = original.TextEncoding;
+		this.logger.WriteLine(encoded);
+		Assert.True(ZcashUtilities.TryParseKey(encoded, out IKeyWithTextEncoding? parsed));
+		UnifiedViewingKey uvk = Assert.IsAssignableFrom<UnifiedViewingKey>(parsed);
+		TKey? parsedKey = uvk.GetViewingKey<TKey>();
+		Assert.NotNull(parsedKey);
+		Assert.Equal(encoded, parsedKey.TextEncoding);
+	}
+}

--- a/test/Nerdbank.Zcash.Tests/Zip321PaymentRequestUrisTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Zip321PaymentRequestUrisTests.cs
@@ -9,7 +9,7 @@ public class Zip321PaymentRequestUrisTests
 	private const string ValidUri1 = "zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?amount=1&memo=VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg&message=Thank%20you%20for%20your%20purchase";
 	private const string ValidUri2 = "zcash:?address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU&amount=123.456&address.1=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amount.1=0.789&memo.1=VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok";
 
-	private static readonly PaymentRequest ValidPaymentRequest1 = new(new PaymentRequestDetails(ZcashAddress.Parse("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez"))
+	private static readonly PaymentRequest ValidPaymentRequest1 = new(new PaymentRequestDetails(ZcashAddress.Decode("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez"))
 	{
 		Memo = Memo.FromMessage("This is a simple memo."),
 		Message = "Thank you for your purchase",
@@ -17,11 +17,11 @@ public class Zip321PaymentRequestUrisTests
 	});
 
 	private static readonly PaymentRequest ValidPaymentRequest2 = new(ImmutableArray.Create(
-		new PaymentRequestDetails(ZcashAddress.Parse("tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"))
+		new PaymentRequestDetails(ZcashAddress.Decode("tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"))
 		{
 			Amount = 123.456m,
 		},
-		new PaymentRequestDetails(ZcashAddress.Parse("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez"))
+		new PaymentRequestDetails(ZcashAddress.Decode("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez"))
 		{
 			Memo = Memo.FromMessage("This is a unicode memo ✨🦄🏆🎉"),
 			Amount = 0.789m,

--- a/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
@@ -149,7 +149,7 @@ public class Zip32HDWalletTests : TestBase
 	}
 
 	[Theory, PairwiseData]
-	public void ExtendedSpendingKey_Sapling_Encoded_FromEncoded(bool testNet)
+	public void ExtendedSpendingKey_Sapling_TextEncoding_TryDecode(bool testNet)
 	{
 		ZcashNetwork network = testNet ? ZcashNetwork.TestNet : ZcashNetwork.MainNet;
 		string expected = testNet
@@ -157,16 +157,16 @@ public class Zip32HDWalletTests : TestBase
 			: "secret-extended-key-main1qvqlw6pjqqqqpqrcxxrqd2acqcurzx7wat9gk7jv3wee36rj970d9h47fpg6fddwupcaun2z7rkqh4hdkkw2y6a2w4x32vg908tpyr63z4akzq4sz5fsm92zmal0puqq9ye7afkkakvg7aurtlrex03dahp7zgfay3dwdkc85t6662jk4lkv8kjughx6x8vrn97pqcqn04wduse3n5hhlkf6qc5ah08udx9g0wpkf6rausju7yamzl6z4gdyrtmqs9ak93w0z222vgsffenlf";
 		Zip32HDWallet wallet = new(Mnemonic, network);
 		Zip32HDWallet.Sapling.ExtendedSpendingKey account = wallet.CreateSaplingAccount(0);
-		string actual = account.Encoded;
+		string actual = account.TextEncoding;
 		this.logger.WriteLine(actual);
 		Assert.Equal(expected, actual);
 
-		var decoded = Zip32HDWallet.Sapling.ExtendedSpendingKey.FromEncoded(actual);
+		Assert.True(Zip32HDWallet.Sapling.ExtendedSpendingKey.TryDecode(actual, out _, out _, out Zip32HDWallet.Sapling.ExtendedSpendingKey? decoded));
 		Assert.Equal(account, decoded);
 	}
 
 	[Theory, PairwiseData]
-	public void ExtendedSpendingKey_Orchard_Encoded_FromEncoded(bool testNet)
+	public void ExtendedSpendingKey_Orchard_TextEncoding_TryDecode(bool testNet)
 	{
 		ZcashNetwork network = testNet ? ZcashNetwork.TestNet : ZcashNetwork.MainNet;
 		string expected = testNet
@@ -174,11 +174,11 @@ public class Zip32HDWalletTests : TestBase
 			: "secret-orchard-extsk-main1qwx8hu3mqqqqpqzr5shlv8gv794seyh4247z7htmgfq7weu7fsk55mxy79uvecdqcd08m73ahd2n4yquhr7uudf9wxhl39qeyjdlam82ue3jusfyxye8y3x62h0";
 		Zip32HDWallet wallet = new(Mnemonic, network);
 		Zip32HDWallet.Orchard.ExtendedSpendingKey account = wallet.CreateOrchardAccount(0);
-		string actual = account.Encoded;
+		string actual = account.TextEncoding;
 		this.logger.WriteLine(actual);
 		Assert.Equal(expected, actual);
 
-		var decoded = Zip32HDWallet.Orchard.ExtendedSpendingKey.FromEncoded(actual);
+		Assert.True(Zip32HDWallet.Orchard.ExtendedSpendingKey.TryDecode(actual, out _, out _, out Zip32HDWallet.Orchard.ExtendedSpendingKey? decoded));
 		Assert.Equal(account, decoded);
 	}
 }


### PR DESCRIPTION
This led to a chain of changes, including adding the `IKeyWithTextEncoding` interface. This made it simpler to maintain a consistent API across all key types so that importing an account can work with a maximum of key types.