### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.7",
+      "version": "7.3.8",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.8.6",
+      "version": "17.9.1",
       "commands": [
         "dotnet-coverage"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,8 +23,8 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="xunit.combinatorial" Version="1.6.24" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageVersion Include="xunit" Version="2.5.2" />
     <PackageVersion Include="ZXing.Net" Version="0.16.9" />
     <PackageVersion Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.12" />
   </ItemGroup>


### PR DESCRIPTION
- Bump xunit.runner.visualstudio from 2.5.1 to 2.5.3 (#224)
- Bump dotnet-coverage from 17.8.6 to 17.9.1 (#222)
- Bump powershell from 7.3.7 to 7.3.8 (#221)
- Bump xunit from 2.5.1 to 2.5.2 (#223)
