### PR TITLE
Add requirements about seed length, and document entropy requirements

### DIFF
--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ abstract Nerdbank.Zcash.UnifiedAddress.Receivers.get -> System.Collections.Gener
 abstract Nerdbank.Zcash.ZcashAddress.GetPoolReceiver<TPoolReceiver>() -> TPoolReceiver?
 abstract Nerdbank.Zcash.ZcashAddress.HasShieldedReceiver.get -> bool
 abstract Nerdbank.Zcash.ZcashAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
+const Nerdbank.Zcash.Zip32HDWallet.MinimumEntropyLengthInBits = 256 -> int
 Nerdbank.Zcash.DiversifierIndex
 Nerdbank.Zcash.DiversifierIndex.DiversifierIndex() -> void
 Nerdbank.Zcash.DiversifierIndex.DiversifierIndex(System.Numerics.BigInteger value) -> void

--- a/src/Nerdbank.Zcash/Strings.resx
+++ b/src/Nerdbank.Zcash/Strings.resx
@@ -156,6 +156,9 @@
   <data name="LengthOutsideExpectedRange" xml:space="preserve">
     <value>The collection was expected to have a length within {minimum}-{maximum} but was {actual}.</value>
   </data>
+  <data name="LengthRangeNotMet" xml:space="preserve">
+    <value>This value must have a length of {minimum}-{maximum}.</value>
+  </data>
   <data name="MemoDataTooLarge" xml:space="preserve">
     <value>The data provided is too large to fit into the memo field.</value>
   </data>

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Orchard.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Orchard.cs
@@ -20,12 +20,15 @@ public partial class Zip32HDWallet
 		/// <summary>
 		/// Creates a master key for the Orchard pool.
 		/// </summary>
-		/// <param name="seed">The seed for use to generate the master key. A given seed will always produce the same master key.</param>
+		/// <param name="seed">
+		/// The seed for use to generate the master key. A given seed will always produce the same master key.
+		/// This seed SHOULD be generated from at least 32-bytes of entropy (e.g. a 24 word seed phrase) to meet Zcash security modeling.
+		/// </param>
 		/// <param name="network">The network this key should be used with.</param>
 		/// <returns>A master extended spending key.</returns>
 		public static ExtendedSpendingKey Create(ReadOnlySpan<byte> seed, ZcashNetwork network)
 		{
-			// Rust: assert!(seed.len() >= 32 && seed.len() <= 252);
+			ThrowIfSeedHasDisallowedSize(seed);
 			Span<byte> blakeOutput = stackalloc byte[64]; // 512 bits
 			Blake2B.ComputeHash(seed, blakeOutput, new Blake2B.Config { Personalization = "ZcashIP32Orchard"u8, OutputSizeInBytes = blakeOutput.Length });
 

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.cs
@@ -20,11 +20,15 @@ public partial class Zip32HDWallet
 		/// <summary>
 		/// Creates a master key for the Sapling pool.
 		/// </summary>
-		/// <param name="seed">The seed byte sequence, which MUST be at least 32 and at most 252 bytes.</param>
+		/// <param name="seed">
+		/// The seed byte sequence, which MUST be at least 32 and at most 252 bytes.
+		/// This seed SHOULD be generated from at least 32-bytes of entropy (e.g. a 24 word seed phrase) to meet Zcash security modeling.
+		/// </param>
 		/// <param name="network">The network this key should be used with.</param>
 		/// <returns>The master extended spending key.</returns>
 		public static ExtendedSpendingKey Create(ReadOnlySpan<byte> seed, ZcashNetwork network)
 		{
+			ThrowIfSeedHasDisallowedSize(seed);
 			Span<byte> blakeOutput = stackalloc byte[64]; // 512 bits
 			Blake2B.ComputeHash(seed, blakeOutput, new Blake2B.Config { Personalization = "ZcashIP32Sapling"u8, OutputSizeInBytes = blakeOutput.Length });
 			ReadOnlySpan<byte> spendingKey = blakeOutput[..32];

--- a/src/Nerdbank.Zcash/Zip32HDWallet.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.cs
@@ -14,6 +14,11 @@ namespace Nerdbank.Zcash;
 public partial class Zip32HDWallet : IEquatable<Zip32HDWallet>
 {
 	/// <summary>
+	/// The number of bits required in the original source (the entropy) used for the seeds used to derive master keys.
+	/// </summary>
+	public const int MinimumEntropyLengthInBits = 256;
+
+	/// <summary>
 	/// The coin type to use in the key derivation path for <see cref="ZcashNetwork.MainNet"/>.
 	/// </summary>
 	private const uint MainNetCoinType = 133;

--- a/src/Nerdbank.Zcash/Zip32HDWallet.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.cs
@@ -28,6 +28,11 @@ public partial class Zip32HDWallet : IEquatable<Zip32HDWallet>
 	/// </summary>
 	private const uint Purpose = 32;
 
+	/// <summary>
+	/// The required length (in bytes) of the seed used to derive master keys.
+	/// </summary>
+	private static readonly (int Min, int Max) MasterSeedAllowedLength = (32, 252);
+
 	private Orchard.ExtendedSpendingKey masterOrchardKey;
 
 	private Sapling.ExtendedSpendingKey masterSaplingKey;
@@ -200,4 +205,15 @@ public partial class Zip32HDWallet : IEquatable<Zip32HDWallet>
 	/// <param name="input">A little-endian ordered encoding of an integer.</param>
 	/// <remarks>This is the inverse operation to <see cref="I2LEOSP(BigInteger, Span{byte})"/>.</remarks>
 	private static BigInteger LEOS2IP(ReadOnlySpan<byte> input) => new(input, isUnsigned: true);
+
+	/// <summary>
+	/// Throws an <see cref="ArgumentException"/> if a given span has a length outside the range allowed by ZIP-32 for purposes of creating a master key.
+	/// </summary>
+	private static void ThrowIfSeedHasDisallowedSize(ReadOnlySpan<byte> seed)
+	{
+		if (seed.Length < MasterSeedAllowedLength.Min || seed.Length > MasterSeedAllowedLength.Max)
+		{
+			throw new ArgumentException(Strings.FormatLengthRangeNotMet(MasterSeedAllowedLength.Min, MasterSeedAllowedLength.Max), nameof(seed));
+		}
+	}
 }

--- a/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
@@ -75,6 +75,20 @@ public class Zip32HDWalletTests : TestBase
 	}
 
 	[Fact]
+	public void Orchard_Create_SeedLengthRequirements()
+	{
+		Assert.Throws<ArgumentException>(() => Zip32HDWallet.Orchard.Create(new byte[31], ZcashNetwork.MainNet));
+		Assert.Throws<ArgumentException>(() => Zip32HDWallet.Orchard.Create(new byte[253], ZcashNetwork.MainNet));
+	}
+
+	[Fact]
+	public void Sapling_Create_SeedLengthRequirements()
+	{
+		Assert.Throws<ArgumentException>(() => Zip32HDWallet.Sapling.Create(new byte[31], ZcashNetwork.MainNet));
+		Assert.Throws<ArgumentException>(() => Zip32HDWallet.Sapling.Create(new byte[253], ZcashNetwork.MainNet));
+	}
+
+	[Fact]
 	public void CreateSaplingAddressFromSeed_ViaFVK()
 	{
 		Zip32HDWallet.Sapling.ExtendedFullViewingKey masterFullViewingKey = Zip32HDWallet.Sapling.Create(Mnemonic, ZcashNetwork.MainNet).ExtendedFullViewingKey;


### PR DESCRIPTION
This accommodates the Zcash security requirements I just became aware of.
Some more explicit wording [will soon be included in ZIP-32 itself](https://github.com/zcash/zips/issues/728).