### PR TITLE
Override `GetHashCode()` in `Zip32HDWallet`

### DIFF
--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -773,6 +773,8 @@ override Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequest.ToString() -> st
 override Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails.Equals(object? obj) -> bool
 override Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails.GetHashCode() -> int
 override Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails.ToString() -> string!
+override Nerdbank.Zcash.Zip32HDWallet.Equals(object? obj) -> bool
+override Nerdbank.Zcash.Zip32HDWallet.GetHashCode() -> int
 override Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey.Derive(uint childIndex) -> Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey!
 override Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey.Equals(object? obj) -> bool
 override Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey.GetHashCode() -> int

--- a/src/Nerdbank.Zcash/Zip32HDWallet.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.cs
@@ -186,6 +186,15 @@ public partial class Zip32HDWallet : IEquatable<Zip32HDWallet>
 			&& this.Network == other.Network;
 	}
 
+	/// <inheritdoc/>
+	public override bool Equals(object? obj) => this.Equals(obj as Zip32HDWallet);
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		return HashCode.Combine(this.Network, BitConverter.ToInt32(this.Seed.Span));
+	}
+
 	/// <summary>
 	/// Encodes a <see cref="BigInteger"/> as a byte sequence in little-endian order.
 	/// </summary>

--- a/test/Nerdbank.Zcash.Tests/RawTransactionTests.cs
+++ b/test/Nerdbank.Zcash.Tests/RawTransactionTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Nerdbank.Zcash.Tests;
-
 public class RawTransactionTests : TestBase
 {
 	/// <summary>

--- a/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
@@ -227,6 +227,12 @@ public class Zip32HDWalletTests : TestBase
 		Zip32HDWallet wallet1 = new(Mnemonic, ZcashNetwork.TestNet);
 		Zip32HDWallet wallet2 = new(Mnemonic, ZcashNetwork.TestNet);
 		Assert.Equal(wallet1, wallet2);
+
+		// Test explicitly with the object.Equals override.
+		Assert.True(wallet1.Equals((object?)wallet2));
+
+		// Test GetHashCode too.
+		Assert.Equal(wallet1.GetHashCode(), wallet2.GetHashCode());
 	}
 
 	[Fact]
@@ -235,6 +241,12 @@ public class Zip32HDWalletTests : TestBase
 		Zip32HDWallet wallet1 = new(Mnemonic, ZcashNetwork.TestNet);
 		Zip32HDWallet wallet2 = new(Mnemonic, ZcashNetwork.MainNet);
 		Assert.NotEqual(wallet1, wallet2);
+
+		// Test explicitly with the object.Equals override.
+		Assert.False(wallet1.Equals((object?)wallet2));
+
+		// Test GetHashCode too.
+		Assert.NotEqual(wallet1.GetHashCode(), wallet2.GetHashCode());
 	}
 
 	[Fact]
@@ -243,6 +255,9 @@ public class Zip32HDWalletTests : TestBase
 		Zip32HDWallet wallet1 = new(Mnemonic, ZcashNetwork.TestNet);
 		Zip32HDWallet wallet2 = new(Mnemonic.Seed, ZcashNetwork.TestNet);
 		Assert.Equal(wallet1, wallet2);
+
+		// Test GetHashCode too.
+		Assert.Equal(wallet1.GetHashCode(), wallet2.GetHashCode());
 	}
 
 	[Fact]
@@ -251,5 +266,11 @@ public class Zip32HDWalletTests : TestBase
 		Zip32HDWallet wallet1 = new(Mnemonic, ZcashNetwork.TestNet);
 		Zip32HDWallet wallet2 = new(Bip39Mnemonic.Create(Zip32HDWallet.MinimumEntropyLengthInBits), ZcashNetwork.TestNet);
 		Assert.NotEqual(wallet1, wallet2);
+
+		// Test explicitly with the object.Equals override.
+		Assert.False(wallet1.Equals((object?)wallet2));
+
+		// Test GetHashCode too.
+		Assert.NotEqual(wallet1.GetHashCode(), wallet2.GetHashCode());
 	}
 }


### PR DESCRIPTION
This makes it capable to use as a key in a dictionary.