### PR TITLE
Add operators to `SecurityAmount` and `ExchangeRate` types for easier transformations

### DIFF
--- a/src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs
+++ b/src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs
@@ -20,6 +20,85 @@ public record struct ExchangeRate(SecurityAmount Basis, SecurityAmount TradeInte
 	/// </summary>
 	public ExchangeRate OppositeDirection => new(this.TradeInterest, this.Basis);
 
+	/// <summary>
+	/// Converts a particular <see cref="SecurityAmount"/> to one that uses a different <see cref="Security"/> by applying a given exchange rate.
+	/// </summary>
+	/// <param name="amount">The base amount. This can be in either unit described by the <paramref name="exchangeRate"/>.</param>
+	/// <param name="exchangeRate">The exchange rate between the security in <paramref name="amount"/> and one other.</param>
+	/// <returns>The converted <see cref="SecurityAmount"/>.</returns>
+	public static SecurityAmount operator *(SecurityAmount amount, ExchangeRate exchangeRate)
+	{
+		if (exchangeRate.Basis.Security == amount.Security)
+		{
+			return new(amount.Amount * exchangeRate.TradeInterest.Amount / exchangeRate.Basis.Amount, exchangeRate.TradeInterest.Security);
+		}
+		else if (exchangeRate.TradeInterest.Security == amount.Security)
+		{
+			return new(amount.Amount * exchangeRate.Basis.Amount / exchangeRate.TradeInterest.Amount, exchangeRate.Basis.Security);
+		}
+		else
+		{
+			throw new ArgumentException("The exchange rate has no security in common with the amount.");
+		}
+	}
+
+	/// <summary>
+	/// Compute an exchange rate using two others that share exactly one security in common.
+	/// The common security will drop out of the result, leaving the two unique remaining securities
+	/// in the computed exchange rate.
+	/// </summary>
+	/// <param name="left">The first exchange rate. The unique security in this value will be used as the basis of the returned exchange rate.</param>
+	/// <param name="right">The second exchange rate. The unique security in this value will be used as the trade interest of the returned exchange rate.</param>
+	/// <returns>An exchange rate made up of the unique securities in each operand.</returns>
+	/// <exception cref="ArgumentException">Thrown if both arguments have the same pair of securities, or if they have no securities in common.</exception>
+	public static ExchangeRate operator *(ExchangeRate left, ExchangeRate right)
+	{
+		// We want to arrange a unit multiplier situation to convert the unique security in left
+		// to the unique security in right.
+		// To do this, we'll arrange for the unique security on the left as the basis
+		// and the unique security on the right as the trade interest.
+		// We'll then multiply the two exchange rates together to get the result.
+		// If the two securities are the same on both left and right, throw an error.
+		if (left.Basis.Security == right.Basis.Security)
+		{
+			// Flip the right so the common security is the trade interest on the right.
+			right = right.OppositeDirection;
+		}
+		else if (left.TradeInterest.Security == right.TradeInterest.Security)
+		{
+			// Flip the left so that the common security is the basis on the left.
+			left = left.OppositeDirection;
+		}
+		else if (left.Basis.Security == right.TradeInterest.Security)
+		{
+			// This is already the way we want it.
+		}
+		else if (left.TradeInterest.Security == right.Basis.Security)
+		{
+			// It's exactly the opposite of what we want, so flipp both sides.
+			(left, right) = (left.OppositeDirection, right.OppositeDirection);
+		}
+		else
+		{
+			throw new ArgumentException(Strings.ExchangeRatesRequireOneCommonSecurity);
+		}
+
+		// Check to see if what we expect to be the unique securities are also in common.
+		if (left.TradeInterest.Security == right.Basis.Security)
+		{
+			throw new ArgumentException(Strings.ExchangeRatesRequireUniqueSecurities);
+		}
+
+		// Get the common security to also match in amount.
+		decimal ratio = left.Basis.Amount / right.TradeInterest.Amount;
+		right = new ExchangeRate(
+			new SecurityAmount(right.Basis.Amount * ratio, right.Basis.Security),
+			new SecurityAmount(right.TradeInterest.Amount * ratio, right.TradeInterest.Security));
+
+		// We can now drop the common security from the result.
+		return new ExchangeRate(left.TradeInterest, right.Basis);
+	}
+
 	/// <inheritdoc/>
 	public override string ToString() => $"{this.Basis} <=> {this.TradeInterest}";
 }

--- a/src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs
+++ b/src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs
@@ -21,6 +21,27 @@ public record struct ExchangeRate(SecurityAmount Basis, SecurityAmount TradeInte
 	public ExchangeRate OppositeDirection => new(this.TradeInterest, this.Basis);
 
 	/// <summary>
+	/// Gets the exchange rate with the <see cref="TradeInterest"/> amount normalized to 1,
+	/// preparing the exchange rate to answer the question "How much of the <see cref="Basis"/> security
+	/// does one unit of <see cref="TradeInterest"/> cost?".
+	/// </summary>
+	public readonly ExchangeRate Normalized
+	{
+		get
+		{
+			if (this.TradeInterest.Amount == 1m)
+			{
+				return this;
+			}
+
+			decimal factor = 1 / this.TradeInterest.Amount;
+			return new(
+				this.Basis.Security.Amount(this.Basis.Amount * factor),
+				this.TradeInterest.Security.Amount(this.TradeInterest.Amount * factor));
+		}
+	}
+
+	/// <summary>
 	/// Converts a particular <see cref="SecurityAmount"/> to one that uses a different <see cref="Security"/> by applying a given exchange rate.
 	/// </summary>
 	/// <param name="amount">The base amount. This can be in either unit described by the <paramref name="exchangeRate"/>.</param>

--- a/src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs
+++ b/src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs
@@ -120,6 +120,18 @@ public record struct ExchangeRate(SecurityAmount Basis, SecurityAmount TradeInte
 		return new ExchangeRate(left.TradeInterest, right.Basis);
 	}
 
+	/// <summary>
+	/// Multiplies an exchange rate by some scalar.
+	/// </summary>
+	/// <param name="rate">The exchange rate to multiply.</param>
+	/// <param name="factor">The factor to multiply the exchange rate by.</param>
+	/// <returns>The result of multiplying the exchange rate by the factor.</returns>
+	/// <remarks>
+	/// This does <em>not</em> change the effectual exchange rate, but it <em>does</em> change its representation.
+	/// For example a 2:1 exchange rate multiplied by 2 will result in a 4:2 exchange rate.
+	/// </remarks>
+	public static ExchangeRate operator *(ExchangeRate rate, decimal factor) => new(rate.Basis * factor, rate.TradeInterest * factor);
+
 	/// <inheritdoc/>
 	public override string ToString() => $"{this.Basis} <=> {this.TradeInterest}";
 }

--- a/src/Nerdbank.Cryptocurrencies/Exchanges/SecurityAmount.cs
+++ b/src/Nerdbank.Cryptocurrencies/Exchanges/SecurityAmount.cs
@@ -53,6 +53,30 @@ public record struct SecurityAmount(decimal Amount, Security Security)
 	/// <returns>The negated amount.</returns>
 	public static SecurityAmount operator -(SecurityAmount right) => new(-right.Amount, right.Security);
 
+	/// <summary>
+	/// Multiplies the amount of a security by a decimal value.
+	/// </summary>
+	/// <param name="left">The amount to multiply.</param>
+	/// <param name="right">The decimal value to multiply by.</param>
+	/// <returns>The product of the multiplication.</returns>
+	public static SecurityAmount operator *(SecurityAmount left, decimal right) => new(left.Amount * right, left.Security);
+
+	/// <summary>
+	/// Multiplies the amount of a security by a decimal value.
+	/// </summary>
+	/// <param name="left">The decimal value to multiply by.</param>
+	/// <param name="right">The amount to multiply.</param>
+	/// <returns>The product of the multiplication.</returns>
+	public static SecurityAmount operator *(decimal left, SecurityAmount right) => right * left;
+
+	/// <summary>
+	/// Divides the amount of a security by a decimal value.
+	/// </summary>
+	/// <param name="left">The amount to divide.</param>
+	/// <param name="right">The decimal value to divide by.</param>
+	/// <returns>The quotient of the division.</returns>
+	public static SecurityAmount operator /(SecurityAmount left, decimal right) => new(left.Amount / right, left.Security);
+
 	/// <inheritdoc/>
 	public override string ToString() => this.Security is not null ? $"{this.Amount.ToString("F" + this.Security.Precision)} {this.Security.TickerSymbol}" : "0";
 }

--- a/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
@@ -174,16 +174,20 @@ static Nerdbank.Cryptocurrencies.CompactSize.Decode(System.ReadOnlySpan<byte> bu
 static Nerdbank.Cryptocurrencies.CompactSize.Encode(ulong value, System.Span<byte> buffer) -> int
 static Nerdbank.Cryptocurrencies.CompactSize.GetEncodedLength(ulong value) -> int
 static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator !=(Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate left, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate right) -> bool
-static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator ==(Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate left, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate right) -> bool
+static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator *(Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate rate, decimal factor) -> Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate
 static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator *(Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate left, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate right) -> Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate
 static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator *(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount amount, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate exchangeRate) -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator ==(Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate left, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate right) -> bool
 static Nerdbank.Cryptocurrencies.Exchanges.Security.operator !=(Nerdbank.Cryptocurrencies.Exchanges.Security? left, Nerdbank.Cryptocurrencies.Exchanges.Security? right) -> bool
 static Nerdbank.Cryptocurrencies.Exchanges.Security.operator ==(Nerdbank.Cryptocurrencies.Exchanges.Security? left, Nerdbank.Cryptocurrencies.Exchanges.Security? right) -> bool
 static Nerdbank.Cryptocurrencies.Exchanges.Security.WellKnown.get -> System.Collections.Immutable.ImmutableDictionary<string!, Nerdbank.Cryptocurrencies.Exchanges.Security!>!
 static Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount.operator !=(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount left, Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount right) -> bool
+static Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount.operator *(decimal left, Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount right) -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+static Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount.operator *(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount left, decimal right) -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
 static Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount.operator +(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount left, Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount right) -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
 static Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount.operator -(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount left, Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount right) -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
 static Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount.operator -(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount right) -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+static Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount.operator /(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount left, decimal right) -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
 static Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount.operator ==(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount left, Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount right) -> bool
 static Nerdbank.Cryptocurrencies.Exchanges.StableCoins.GetSecuritiesSharingPeg(Nerdbank.Cryptocurrencies.Exchanges.Security! security) -> System.Collections.Generic.IReadOnlySet<Nerdbank.Cryptocurrencies.Exchanges.Security!>!
 static Nerdbank.Cryptocurrencies.Exchanges.TradingPair.operator !=(Nerdbank.Cryptocurrencies.Exchanges.TradingPair left, Nerdbank.Cryptocurrencies.Exchanges.TradingPair right) -> bool

--- a/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
@@ -174,6 +174,8 @@ static Nerdbank.Cryptocurrencies.CompactSize.Encode(ulong value, System.Span<byt
 static Nerdbank.Cryptocurrencies.CompactSize.GetEncodedLength(ulong value) -> int
 static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator !=(Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate left, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate right) -> bool
 static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator ==(Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate left, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate right) -> bool
+static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator *(Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate left, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate right) -> Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate
+static Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.operator *(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount amount, Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate exchangeRate) -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
 static Nerdbank.Cryptocurrencies.Exchanges.Security.operator !=(Nerdbank.Cryptocurrencies.Exchanges.Security? left, Nerdbank.Cryptocurrencies.Exchanges.Security? right) -> bool
 static Nerdbank.Cryptocurrencies.Exchanges.Security.operator ==(Nerdbank.Cryptocurrencies.Exchanges.Security? left, Nerdbank.Cryptocurrencies.Exchanges.Security? right) -> bool
 static Nerdbank.Cryptocurrencies.Exchanges.Security.WellKnown.get -> System.Collections.Immutable.ImmutableDictionary<string!, Nerdbank.Cryptocurrencies.Exchanges.Security!>!

--- a/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
@@ -80,6 +80,7 @@ Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.Equals(Nerdbank.Cryptocurrencie
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.ExchangeRate() -> void
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.ExchangeRate(Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount Basis, Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount TradeInterest) -> void
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.InBasisAmount.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.Normalized.get -> Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.OppositeDirection.get -> Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.TradeInterest.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.TradeInterest.set -> void

--- a/src/Nerdbank.Cryptocurrencies/Strings.es.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.es.resx
@@ -162,4 +162,10 @@
   <data name="HistoricalPriceNotAvailableForThisDate" xml:space="preserve">
     <value>El precio histórico de este par de trading en ese momento no está disponible.</value>
   </data>
+  <data name="ExchangeRatesRequireOneCommonSecurity" xml:space="preserve">
+    <value>Los tipos de cambio no tienen ninguna seguridad en común.</value>
+  </data>
+  <data name="ExchangeRatesRequireUniqueSecurities" xml:space="preserve">
+    <value>Los tipos de cambio describen los mismos dos valores.</value>
+  </data>
 </root>

--- a/src/Nerdbank.Cryptocurrencies/Strings.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.resx
@@ -126,6 +126,12 @@
   <data name="DecodeInputTooShort" xml:space="preserve">
     <value>The input length is shorter than the minimum required for this encoding.</value>
   </data>
+  <data name="ExchangeRatesRequireOneCommonSecurity" xml:space="preserve">
+    <value>The exchange rates have no security in common.</value>
+  </data>
+  <data name="ExchangeRatesRequireUniqueSecurities" xml:space="preserve">
+    <value>The exchange rates describe the same two securities. No transformation can be made.</value>
+  </data>
   <data name="HistoricalPriceNotAvailableForThisDate" xml:space="preserve">
     <value>The historical price for this trading pair at the given time is not available.</value>
   </data>

--- a/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/ExchangeRateTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/ExchangeRateTests.cs
@@ -146,6 +146,14 @@ public class ExchangeRateTests : TestBase
 	}
 
 	[Fact]
+	public void MultiplyByScalar()
+	{
+		Assert.Equal(Rate(2, 4), Rate(1, 2) * 2);
+
+		ExchangeRate Rate(decimal basis, decimal tradeInterest) => new(Security.USD.Amount(basis), Security.ZEC.Amount(tradeInterest));
+	}
+
+	[Fact]
 	public void Normalized()
 	{
 		Assert.Equal(Rate(30, 1), Rate(60, 2).Normalized);

--- a/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/ExchangeRateTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/ExchangeRateTests.cs
@@ -144,4 +144,13 @@ public class ExchangeRateTests : TestBase
 		SecurityAmount ltc = zec * usdZec * btcUsd * ethBtc * ltcEth;
 		Assert.Equal(Security.LTC.Amount(1.8m), ltc);
 	}
+
+	[Fact]
+	public void Normalized()
+	{
+		Assert.Equal(Rate(30, 1), Rate(60, 2).Normalized);
+		Assert.Equal(Rate(30, 1), Rate(15, 0.5m).Normalized);
+
+		ExchangeRate Rate(decimal basis, decimal tradeInterest) => new(Security.USD.Amount(basis), Security.ZEC.Amount(tradeInterest));
+	}
 }

--- a/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/ExchangeRateTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/ExchangeRateTests.cs
@@ -40,4 +40,108 @@ public class ExchangeRateTests : TestBase
 		ExchangeRate opposite = rate.OppositeDirection;
 		Assert.Equal(new ExchangeRate(tradeInterest, basis), opposite);
 	}
+
+	[Fact]
+	public void Asset_Times_ExchangeRate()
+	{
+		ExchangeRate usdToZec = new(new SecurityAmount(30m, Security.USD), new SecurityAmount(1m, Security.ZEC));
+
+		SecurityAmount zec = Security.ZEC.Amount(2);
+		Assert.Equal(Security.USD.Amount(60), zec * usdToZec);
+		Assert.Equal(Security.USD.Amount(60), zec * usdToZec.OppositeDirection);
+	}
+
+	[Fact]
+	public void UnrelatedAsset_Times_ExchangeRate()
+	{
+		ExchangeRate usdToZec = new(new SecurityAmount(30m, Security.USD), new SecurityAmount(1m, Security.ZEC));
+		Assert.Throws<ArgumentException>(() => Security.BTC.Amount(1) * usdToZec);
+	}
+
+	[Fact]
+	public void ExchangeRate_Times_ExchangeRate1()
+	{
+		ExchangeRate usdToZec = new(new SecurityAmount(60m, Security.USD), new SecurityAmount(2m, Security.ZEC));
+		ExchangeRate usdToBtc = new(new SecurityAmount(45_000m, Security.USD), new SecurityAmount(1.5m, Security.BTC));
+
+		ExchangeRate zecToBtc = usdToZec * usdToBtc;
+		Assert.Equal(Security.ZEC, zecToBtc.Basis.Security);
+		Assert.Equal(Security.BTC, zecToBtc.TradeInterest.Security);
+
+		SecurityAmount zec = Security.ZEC.Amount(500);
+		SecurityAmount btc = zec * zecToBtc;
+		Assert.Equal(Security.BTC.Amount(0.5m), btc);
+	}
+
+	[Fact]
+	public void ExchangeRate_Times_ExchangeRate2()
+	{
+		ExchangeRate usdToZec = new(new SecurityAmount(60m, Security.USD), new SecurityAmount(2m, Security.ZEC));
+		ExchangeRate usdToBtc = new(new SecurityAmount(45_000m, Security.USD), new SecurityAmount(1.5m, Security.BTC));
+
+		ExchangeRate zecToBtc = usdToZec * usdToBtc.OppositeDirection;
+		Assert.Equal(Security.ZEC, zecToBtc.Basis.Security);
+		Assert.Equal(Security.BTC, zecToBtc.TradeInterest.Security);
+
+		SecurityAmount zec = Security.ZEC.Amount(500);
+		SecurityAmount btc = zec * zecToBtc;
+		Assert.Equal(Security.BTC.Amount(0.5m), btc);
+	}
+
+	[Fact]
+	public void ExchangeRate_Times_ExchangeRate3()
+	{
+		ExchangeRate usdToZec = new(new SecurityAmount(60m, Security.USD), new SecurityAmount(2m, Security.ZEC));
+		ExchangeRate usdToBtc = new(new SecurityAmount(45_000m, Security.USD), new SecurityAmount(1.5m, Security.BTC));
+
+		ExchangeRate zecToBtc = usdToZec.OppositeDirection * usdToBtc;
+		Assert.Equal(Security.ZEC, zecToBtc.Basis.Security);
+		Assert.Equal(Security.BTC, zecToBtc.TradeInterest.Security);
+
+		SecurityAmount zec = Security.ZEC.Amount(500);
+		SecurityAmount btc = zec * zecToBtc;
+		Assert.Equal(Security.BTC.Amount(0.5m), btc);
+	}
+
+	[Fact]
+	public void ExchangeRate_Times_ExchangeRate4()
+	{
+		ExchangeRate usdToZec = new(new SecurityAmount(60m, Security.USD), new SecurityAmount(2m, Security.ZEC));
+		ExchangeRate usdToBtc = new(new SecurityAmount(45_000m, Security.USD), new SecurityAmount(1.5m, Security.BTC));
+
+		ExchangeRate zecToBtc = usdToZec.OppositeDirection * usdToBtc.OppositeDirection;
+		Assert.Equal(Security.ZEC, zecToBtc.Basis.Security);
+		Assert.Equal(Security.BTC, zecToBtc.TradeInterest.Security);
+
+		SecurityAmount zec = Security.ZEC.Amount(500);
+		SecurityAmount btc = zec * zecToBtc;
+		Assert.Equal(Security.BTC.Amount(0.5m), btc);
+	}
+
+	[Fact]
+	public void ExchangeRate_Times_UnrelatedExchangeRate()
+	{
+		ExchangeRate usdToZec = new(new SecurityAmount(60m, Security.USD), new SecurityAmount(2m, Security.ZEC));
+		ExchangeRate ethToBtc = new(new SecurityAmount(45m, Security.ETH), new SecurityAmount(1.5m, Security.BTC));
+		Assert.Throws<ArgumentException>(() => usdToZec * ethToBtc);
+	}
+
+	[Fact]
+	public void ExchangeRate_Times_ExchangeRateWithSameUnits()
+	{
+		ExchangeRate usdToZec = new(new SecurityAmount(60m, Security.USD), new SecurityAmount(2m, Security.ZEC));
+		Assert.Throws<ArgumentException>(() => usdToZec * usdToZec);
+	}
+
+	[Fact]
+	public void ExchangeRateChain()
+	{
+		SecurityAmount zec = Security.ZEC.Amount(5);
+		ExchangeRate usdZec = new(Security.USD.Amount(60m), Security.ZEC.Amount(2m));
+		ExchangeRate btcUsd = new(Security.USD.Amount(45_000m), Security.BTC.Amount(1.5m));
+		ExchangeRate ethBtc = new(Security.ETH.Amount(45m), Security.BTC.Amount(2.5m));
+		ExchangeRate ltcEth = new(Security.LTC.Amount(60m), Security.ETH.Amount(3m));
+		SecurityAmount ltc = zec * usdZec * btcUsd * ethBtc * ltcEth;
+		Assert.Equal(Security.LTC.Amount(1.8m), ltc);
+	}
 }

--- a/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/SecurityAmountTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/SecurityAmountTests.cs
@@ -41,6 +41,19 @@ public class SecurityAmountTests
 	}
 
 	[Fact]
+	public void Multiply()
+	{
+		Assert.Equal(Security.USD.Amount(15), Security.USD.Amount(5) * 3);
+		Assert.Equal(Security.USD.Amount(15), 3 * Security.USD.Amount(5));
+	}
+
+	[Fact]
+	public void Divide()
+	{
+		Assert.Equal(Security.USD.Amount(15), Security.USD.Amount(45) / 3);
+	}
+
+	[Fact]
 	public void ToString_Formatting()
 	{
 		Assert.Equal("1.20000000 ZEC", new SecurityAmount(1.2m, Security.ZEC).ToString());


### PR DESCRIPTION
- Add more operators to Exchanges types
- Add `ExchangeRate.Normalized` property
- Teach `ExchangeRate` how to apply to a security or to each other