### PR TITLE
Add rust calculation of meaningful user balances

### DIFF
--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -39,6 +39,7 @@ Nerdbank.Zcash.LightWalletClient.DownloadTransactionsAsync(System.Threading.Canc
 Nerdbank.Zcash.LightWalletClient.GetDownloadedTransactions(uint startingBlock = 0) -> System.Collections.Generic.List<Nerdbank.Zcash.LightWalletClient.Transaction!>!
 Nerdbank.Zcash.LightWalletClient.GetLatestBlockHeightAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<ulong>
 Nerdbank.Zcash.LightWalletClient.GetPoolBalances() -> Nerdbank.Zcash.LightWalletClient.PoolBalances
+Nerdbank.Zcash.LightWalletClient.GetUserBalances() -> Nerdbank.Zcash.LightWalletClient.UserBalances!
 Nerdbank.Zcash.LightWalletClient.LastDownloadHeight.get -> ulong
 Nerdbank.Zcash.LightWalletClient.LightWalletClient(System.Uri! serverUrl, Nerdbank.Zcash.ZcashAccount! account, string! walletPath, string! walletName, string! logName, bool watchMemPool) -> void
 Nerdbank.Zcash.LightWalletClient.LightWalletClient(System.Uri! serverUrl, Nerdbank.Zcash.ZcashNetwork network, string! walletPath, string! walletName, string! logName, bool watchMemPool) -> void
@@ -177,6 +178,24 @@ Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.TransparentPoolBalance()
 Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.TransparentPoolBalance(decimal Balance) -> void
 Nerdbank.Zcash.LightWalletClient.UpdateFrequency.get -> System.TimeSpan
 Nerdbank.Zcash.LightWalletClient.UpdateFrequency.set -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances
+Nerdbank.Zcash.LightWalletClient.UserBalances.FairyDust.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Zcash.LightWalletClient.UserBalances.FairyDust.init -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances.ImmatureChange.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Zcash.LightWalletClient.UserBalances.ImmatureChange.init -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances.ImmatureIncome.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Zcash.LightWalletClient.UserBalances.ImmatureIncome.init -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances.Incoming.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Zcash.LightWalletClient.UserBalances.Incoming.init -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances.IncomingFairyDust.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Zcash.LightWalletClient.UserBalances.IncomingFairyDust.init -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances.MainBalance.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Zcash.LightWalletClient.UserBalances.MinimumFees.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Zcash.LightWalletClient.UserBalances.MinimumFees.init -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances.Spendable.get -> Nerdbank.Cryptocurrencies.Exchanges.SecurityAmount
+Nerdbank.Zcash.LightWalletClient.UserBalances.Spendable.init -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances.UserBalances() -> void
+Nerdbank.Zcash.LightWalletClient.UserBalances.UserBalances(Nerdbank.Zcash.LightWalletClient.UserBalances! original) -> void
 Nerdbank.Zcash.LightWalletException
 Nerdbank.Zcash.LightWalletException.LightWalletException(string? message) -> void
 Nerdbank.Zcash.LightWalletException.LightWalletException(string? message, System.Exception? innerException) -> void
@@ -715,6 +734,9 @@ override Nerdbank.Zcash.LightWalletClient.Transaction.ToString() -> string!
 override Nerdbank.Zcash.LightWalletClient.TransactionRecvItem.GetHashCode() -> int
 override Nerdbank.Zcash.LightWalletClient.TransactionSendItem.GetHashCode() -> int
 override Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.GetHashCode() -> int
+override Nerdbank.Zcash.LightWalletClient.UserBalances.Equals(object? obj) -> bool
+override Nerdbank.Zcash.LightWalletClient.UserBalances.GetHashCode() -> int
+override Nerdbank.Zcash.LightWalletClient.UserBalances.ToString() -> string!
 override Nerdbank.Zcash.Memo.ToString() -> string!
 override Nerdbank.Zcash.Orchard.FullViewingKey.Equals(object? obj) -> bool
 override Nerdbank.Zcash.Orchard.FullViewingKey.GetHashCode() -> int
@@ -811,6 +833,8 @@ static Nerdbank.Zcash.LightWalletClient.TransactionSendItem.operator !=(Nerdbank
 static Nerdbank.Zcash.LightWalletClient.TransactionSendItem.operator ==(Nerdbank.Zcash.LightWalletClient.TransactionSendItem left, Nerdbank.Zcash.LightWalletClient.TransactionSendItem right) -> bool
 static Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.operator !=(Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance left, Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance right) -> bool
 static Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.operator ==(Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance left, Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance right) -> bool
+static Nerdbank.Zcash.LightWalletClient.UserBalances.operator !=(Nerdbank.Zcash.LightWalletClient.UserBalances? left, Nerdbank.Zcash.LightWalletClient.UserBalances? right) -> bool
+static Nerdbank.Zcash.LightWalletClient.UserBalances.operator ==(Nerdbank.Zcash.LightWalletClient.UserBalances? left, Nerdbank.Zcash.LightWalletClient.UserBalances? right) -> bool
 static Nerdbank.Zcash.ManagedLightWalletClient.CreateAsync(System.Uri! serverUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Nerdbank.Zcash.ManagedLightWalletClient!>
 static Nerdbank.Zcash.Memo.FromMessage(string? message) -> Nerdbank.Zcash.Memo
 static Nerdbank.Zcash.Memo.NoMemo.get -> Nerdbank.Zcash.Memo
@@ -920,6 +944,10 @@ virtual Nerdbank.Zcash.LightWalletClient.Transaction.<Clone>$() -> Nerdbank.Zcas
 virtual Nerdbank.Zcash.LightWalletClient.Transaction.EqualityContract.get -> System.Type!
 virtual Nerdbank.Zcash.LightWalletClient.Transaction.Equals(Nerdbank.Zcash.LightWalletClient.Transaction? other) -> bool
 virtual Nerdbank.Zcash.LightWalletClient.Transaction.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Nerdbank.Zcash.LightWalletClient.UserBalances.<Clone>$() -> Nerdbank.Zcash.LightWalletClient.UserBalances!
+virtual Nerdbank.Zcash.LightWalletClient.UserBalances.EqualityContract.get -> System.Type!
+virtual Nerdbank.Zcash.LightWalletClient.UserBalances.Equals(Nerdbank.Zcash.LightWalletClient.UserBalances? other) -> bool
+virtual Nerdbank.Zcash.LightWalletClient.UserBalances.PrintMembers(System.Text.StringBuilder! builder) -> bool
 virtual Nerdbank.Zcash.ZcashAccount.FullViewingKeys.<Clone>$() -> Nerdbank.Zcash.ZcashAccount.FullViewingKeys!
 virtual Nerdbank.Zcash.ZcashAccount.FullViewingKeys.EqualityContract.get -> System.Type!
 virtual Nerdbank.Zcash.ZcashAccount.FullViewingKeys.Equals(Nerdbank.Zcash.ZcashAccount.FullViewingKeys? other) -> bool

--- a/src/Nerdbank.Zcash/RustBindings/LightWallet.cs
+++ b/src/Nerdbank.Zcash/RustBindings/LightWallet.cs
@@ -19,7 +19,7 @@ internal struct RustBuffer {
 
     public static RustBuffer Alloc(int size) {
         return _UniffiHelpers.RustCall((ref RustCallStatus status) => {
-            var buffer = _UniFFILib.ffi_LightWallet_796f_rustbuffer_alloc(size, ref status);
+            var buffer = _UniFFILib.ffi_LightWallet_f882_rustbuffer_alloc(size, ref status);
             if (buffer.data == IntPtr.Zero) {
                 throw new AllocationException($"RustBuffer.Alloc() returned null data pointer (size={size})");
             }
@@ -29,7 +29,7 @@ internal struct RustBuffer {
 
     public static void Free(RustBuffer buffer) {
         _UniffiHelpers.RustCall((ref RustCallStatus status) => {
-            _UniFFILib.ffi_LightWallet_796f_rustbuffer_free(buffer, ref status);
+            _UniFFILib.ffi_LightWallet_f882_rustbuffer_free(buffer, ref status);
         });
     }
 
@@ -396,87 +396,92 @@ static class _UniFFILib {
         }
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern ulong LightWallet_796f_lightwallet_get_block_height(RustBuffer @serverUri,
+    public static extern ulong LightWallet_f882_lightwallet_get_block_height(RustBuffer @serverUri,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern ulong LightWallet_796f_lightwallet_initialize(RustBuffer @config,RustBuffer @walletInfo,
+    public static extern ulong LightWallet_f882_lightwallet_initialize(RustBuffer @config,RustBuffer @walletInfo,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern ulong LightWallet_796f_lightwallet_initialize_from_disk(RustBuffer @config,
+    public static extern ulong LightWallet_f882_lightwallet_initialize_from_disk(RustBuffer @config,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern sbyte LightWallet_796f_lightwallet_deinitialize(ulong @handle,
+    public static extern sbyte LightWallet_f882_lightwallet_deinitialize(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer LightWallet_796f_lightwallet_sync(ulong @handle,
+    public static extern RustBuffer LightWallet_f882_lightwallet_sync(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern void LightWallet_796f_lightwallet_sync_interrupt(ulong @handle,
+    public static extern void LightWallet_f882_lightwallet_sync_interrupt(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer LightWallet_796f_lightwallet_sync_status(ulong @handle,
+    public static extern RustBuffer LightWallet_f882_lightwallet_sync_status(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern ulong LightWallet_796f_lightwallet_get_birthday_height(ulong @handle,
+    public static extern ulong LightWallet_f882_lightwallet_get_birthday_height(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern ulong LightWallet_796f_last_synced_height(ulong @handle,
+    public static extern ulong LightWallet_f882_last_synced_height(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer LightWallet_796f_lightwallet_get_transactions(ulong @handle,uint @startingBlock,
+    public static extern RustBuffer LightWallet_f882_lightwallet_get_transactions(ulong @handle,uint @startingBlock,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer LightWallet_796f_lightwallet_send_to_address(ulong @handle,RustBuffer @sendDetails,
+    public static extern RustBuffer LightWallet_f882_lightwallet_send_to_address(ulong @handle,RustBuffer @sendDetails,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer LightWallet_796f_lightwallet_send_check_status(ulong @handle,
+    public static extern RustBuffer LightWallet_f882_lightwallet_send_check_status(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer LightWallet_796f_lightwallet_get_balances(ulong @handle,
+    public static extern RustBuffer LightWallet_f882_lightwallet_get_balances(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer ffi_LightWallet_796f_rustbuffer_alloc(int @size,
+    public static extern RustBuffer LightWallet_f882_lightwallet_get_user_balances(ulong @handle,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer ffi_LightWallet_796f_rustbuffer_from_bytes(ForeignBytes @bytes,
+    public static extern RustBuffer ffi_LightWallet_f882_rustbuffer_alloc(int @size,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern void ffi_LightWallet_796f_rustbuffer_free(RustBuffer @buf,
+    public static extern RustBuffer ffi_LightWallet_f882_rustbuffer_from_bytes(ForeignBytes @bytes,
     ref RustCallStatus _uniffi_out_err
     );
 
     [DllImport("nerdbank_zcash_rust")]
-    public static extern RustBuffer ffi_LightWallet_796f_rustbuffer_reserve(RustBuffer @buf,int @additional,
+    public static extern void ffi_LightWallet_f882_rustbuffer_free(RustBuffer @buf,
+    ref RustCallStatus _uniffi_out_err
+    );
+
+    [DllImport("nerdbank_zcash_rust")]
+    public static extern RustBuffer ffi_LightWallet_f882_rustbuffer_reserve(RustBuffer @buf,int @additional,
     ref RustCallStatus _uniffi_out_err
     );
 
@@ -1101,6 +1106,56 @@ class FfiConverterTypeTransactionSendDetail: FfiConverterRustBuffer<TransactionS
 
 
 
+public record UserBalances (
+    UInt64 @spendable, 
+    UInt64 @immatureChange, 
+    UInt64 @minimumFees, 
+    UInt64 @immatureIncome, 
+    UInt64 @fairyDust, 
+    UInt64 @incoming, 
+    UInt64 @incomingFairyDust
+) {
+}
+
+class FfiConverterTypeUserBalances: FfiConverterRustBuffer<UserBalances> {
+    public static FfiConverterTypeUserBalances INSTANCE = new FfiConverterTypeUserBalances();
+
+    public override UserBalances Read(BigEndianStream stream) {
+        return new UserBalances(
+            FfiConverterULong.INSTANCE.Read(stream),
+            FfiConverterULong.INSTANCE.Read(stream),
+            FfiConverterULong.INSTANCE.Read(stream),
+            FfiConverterULong.INSTANCE.Read(stream),
+            FfiConverterULong.INSTANCE.Read(stream),
+            FfiConverterULong.INSTANCE.Read(stream),
+            FfiConverterULong.INSTANCE.Read(stream)
+        );
+    }
+
+    public override int AllocationSize(UserBalances value) {
+        return
+            FfiConverterULong.INSTANCE.AllocationSize(value.@spendable) +
+            FfiConverterULong.INSTANCE.AllocationSize(value.@immatureChange) +
+            FfiConverterULong.INSTANCE.AllocationSize(value.@minimumFees) +
+            FfiConverterULong.INSTANCE.AllocationSize(value.@immatureIncome) +
+            FfiConverterULong.INSTANCE.AllocationSize(value.@fairyDust) +
+            FfiConverterULong.INSTANCE.AllocationSize(value.@incoming) +
+            FfiConverterULong.INSTANCE.AllocationSize(value.@incomingFairyDust);
+    }
+
+    public override void Write(UserBalances value, BigEndianStream stream) {
+            FfiConverterULong.INSTANCE.Write(value.@spendable, stream);
+            FfiConverterULong.INSTANCE.Write(value.@immatureChange, stream);
+            FfiConverterULong.INSTANCE.Write(value.@minimumFees, stream);
+            FfiConverterULong.INSTANCE.Write(value.@immatureIncome, stream);
+            FfiConverterULong.INSTANCE.Write(value.@fairyDust, stream);
+            FfiConverterULong.INSTANCE.Write(value.@incoming, stream);
+            FfiConverterULong.INSTANCE.Write(value.@incomingFairyDust, stream);
+    }
+}
+
+
+
 public record WalletInfo (
     String? @ufvk, 
     List<Byte>? @unifiedSpendingKey, 
@@ -1553,7 +1608,7 @@ public static class LightWalletMethods {
     public static UInt64 LightwalletGetBlockHeight(String @serverUri) {
         return FfiConverterULong.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_get_block_height(FfiConverterString.INSTANCE.Lower(@serverUri), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_get_block_height(FfiConverterString.INSTANCE.Lower(@serverUri), ref _status)
 ));
     }
 
@@ -1561,7 +1616,7 @@ public static class LightWalletMethods {
     public static UInt64 LightwalletInitialize(Config @config, WalletInfo @walletInfo) {
         return FfiConverterULong.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_initialize(FfiConverterTypeConfig.INSTANCE.Lower(@config), FfiConverterTypeWalletInfo.INSTANCE.Lower(@walletInfo), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_initialize(FfiConverterTypeConfig.INSTANCE.Lower(@config), FfiConverterTypeWalletInfo.INSTANCE.Lower(@walletInfo), ref _status)
 ));
     }
 
@@ -1569,14 +1624,14 @@ public static class LightWalletMethods {
     public static UInt64 LightwalletInitializeFromDisk(Config @config) {
         return FfiConverterULong.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_initialize_from_disk(FfiConverterTypeConfig.INSTANCE.Lower(@config), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_initialize_from_disk(FfiConverterTypeConfig.INSTANCE.Lower(@config), ref _status)
 ));
     }
 
     public static Boolean LightwalletDeinitialize(UInt64 @handle) {
         return FfiConverterBoolean.INSTANCE.Lift(
     _UniffiHelpers.RustCall( (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_deinitialize(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_deinitialize(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
 ));
     }
 
@@ -1584,7 +1639,7 @@ public static class LightWalletMethods {
     public static SyncResult LightwalletSync(UInt64 @handle) {
         return FfiConverterTypeSyncResult.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_sync(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_sync(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
 ));
     }
 
@@ -1592,7 +1647,7 @@ public static class LightWalletMethods {
     public static void LightwalletSyncInterrupt(UInt64 @handle) {
         
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_sync_interrupt(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_sync_interrupt(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
 );
     }
 
@@ -1600,7 +1655,7 @@ public static class LightWalletMethods {
     public static SyncStatus LightwalletSyncStatus(UInt64 @handle) {
         return FfiConverterTypeSyncStatus.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_sync_status(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_sync_status(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
 ));
     }
 
@@ -1608,7 +1663,7 @@ public static class LightWalletMethods {
     public static UInt64 LightwalletGetBirthdayHeight(UInt64 @handle) {
         return FfiConverterULong.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_get_birthday_height(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_get_birthday_height(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
 ));
     }
 
@@ -1616,7 +1671,7 @@ public static class LightWalletMethods {
     public static UInt64 LastSyncedHeight(UInt64 @handle) {
         return FfiConverterULong.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_last_synced_height(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+    _UniFFILib.LightWallet_f882_last_synced_height(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
 ));
     }
 
@@ -1624,7 +1679,7 @@ public static class LightWalletMethods {
     public static List<Transaction> LightwalletGetTransactions(UInt64 @handle, UInt32 @startingBlock) {
         return FfiConverterSequenceTypeTransaction.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_get_transactions(FfiConverterULong.INSTANCE.Lower(@handle), FfiConverterUInt.INSTANCE.Lower(@startingBlock), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_get_transactions(FfiConverterULong.INSTANCE.Lower(@handle), FfiConverterUInt.INSTANCE.Lower(@startingBlock), ref _status)
 ));
     }
 
@@ -1632,7 +1687,7 @@ public static class LightWalletMethods {
     public static String LightwalletSendToAddress(UInt64 @handle, List<TransactionSendDetail> @sendDetails) {
         return FfiConverterString.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_send_to_address(FfiConverterULong.INSTANCE.Lower(@handle), FfiConverterSequenceTypeTransactionSendDetail.INSTANCE.Lower(@sendDetails), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_send_to_address(FfiConverterULong.INSTANCE.Lower(@handle), FfiConverterSequenceTypeTransactionSendDetail.INSTANCE.Lower(@sendDetails), ref _status)
 ));
     }
 
@@ -1640,7 +1695,7 @@ public static class LightWalletMethods {
     public static SendUpdate LightwalletSendCheckStatus(UInt64 @handle) {
         return FfiConverterTypeSendUpdate.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_send_check_status(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_send_check_status(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
 ));
     }
 
@@ -1648,7 +1703,15 @@ public static class LightWalletMethods {
     public static PoolBalances LightwalletGetBalances(UInt64 @handle) {
         return FfiConverterTypePoolBalances.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
-    _UniFFILib.LightWallet_796f_lightwallet_get_balances(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+    _UniFFILib.LightWallet_f882_lightwallet_get_balances(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
+));
+    }
+
+    /// <exception cref="LightWalletException"></exception>
+    public static UserBalances LightwalletGetUserBalances(UInt64 @handle) {
+        return FfiConverterTypeUserBalances.INSTANCE.Lift(
+    _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletError.INSTANCE, (ref RustCallStatus _status) =>
+    _UniFFILib.LightWallet_f882_lightwallet_get_user_balances(FfiConverterULong.INSTANCE.Lower(@handle), ref _status)
 ));
     }
 

--- a/src/nerdbank-zcash-rust/src/ffi.udl
+++ b/src/nerdbank-zcash-rust/src/ffi.udl
@@ -108,6 +108,16 @@ dictionary PoolBalances {
 	u64? transparent_balance;
 };
 
+dictionary UserBalances {
+    u64 spendable;
+    u64 immature_change;
+    u64 minimum_fees;
+    u64 immature_income;
+    u64 fairy_dust;
+    u64 incoming;
+    u64 incoming_fairy_dust;
+};
+
 namespace LightWallet {
 	[Throws=LightWalletError]
 	u64 lightwallet_get_block_height(string server_uri);
@@ -146,4 +156,7 @@ namespace LightWallet {
 
 	[Throws=LightWalletError]
 	PoolBalances lightwallet_get_balances(u64 handle);
+	
+	[Throws=LightWalletError]
+	UserBalances lightwallet_get_user_balances(u64 handle);
 };

--- a/src/nerdbank-zcash-rust/src/lib.rs
+++ b/src/nerdbank-zcash-rust/src/lib.rs
@@ -10,9 +10,10 @@ mod sapling;
 use lightwallet::{
     last_synced_height, lightwallet_deinitialize, lightwallet_get_balances,
     lightwallet_get_birthday_height, lightwallet_get_block_height, lightwallet_get_transactions,
-    lightwallet_initialize, lightwallet_initialize_from_disk, lightwallet_send_check_status,
-    lightwallet_send_to_address, lightwallet_sync, lightwallet_sync_interrupt,
-    lightwallet_sync_status, ChainType, Config, LightWalletError, OrchardNote, SaplingNote,
-    SendUpdate, SyncStatus, Transaction, TransactionSendDetail, WalletInfo,
+    lightwallet_get_user_balances, lightwallet_initialize, lightwallet_initialize_from_disk,
+    lightwallet_send_check_status, lightwallet_send_to_address, lightwallet_sync,
+    lightwallet_sync_interrupt, lightwallet_sync_status, ChainType, Config, LightWalletError,
+    OrchardNote, SaplingNote, SendUpdate, SyncStatus, Transaction, TransactionSendDetail,
+    UserBalances, WalletInfo,
 };
 use zingolib::lightclient::{PoolBalances, SyncResult};


### PR DESCRIPTION
This new struct describes balances in a way that a user is likely to (need to) understand. Some fields may be too technical and may be omitted by an app or combined with other fields.

Balances are divided such that an app that chooses a different policy for what to convey to the user should be able to add or subtract fields from each other to produce whatever value they see fit.

Here is a possible Balance view based on these changes:
![image](https://github.com/nerdcash/Nerdbank.Cryptocurrencies/assets/3548/50298b61-d5b0-4aba-9d01-8e053e361ebc)

Only non-zero rows would be shown in order to keep the UI as simple as possible.