### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,12 +8,6 @@
         "pwsh"
       ]
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "dotnet-coverage": {
       "version": "17.9.3",
       "commands": [

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
   directory: /
   schedule:
     interval: weekly
-  ignore:
-  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
-  - dependency-name: dotnet-format
-    versions: ["6.x", "7.x", "8.x", "9.x"]
 - package-ecosystem: cargo
   directory: /src/nerdbank-zcash-rust
   schedule:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
 	"omnisharp.enableEditorConfigSupport": true,
 	"omnisharp.enableRoslynAnalyzers": true,
 	"dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+	"editor.formatOnSave": true,
 	"dotnet.defaultSolution": "Nerdbank.Cryptocurrencies.sln",
 	"rust-analyzer.linkedProjects": [
 		".\\src\\nerdbank-zcash-rust\\Cargo.toml"

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -35,6 +35,8 @@ jobs:
   - template: dotnet.yml
     parameters:
       RunTests: ${{ parameters.RunTests }}
+  - script: dotnet format --verify-no-changes --no-restore
+    displayName: 💅 Verify formatted code
 
 - job: macOS
   condition: ${{ parameters.includeMacOS }}

--- a/settings.VisualStudio.json
+++ b/settings.VisualStudio.json
@@ -1,0 +1,3 @@
+{
+  "textEditor.codeCleanup.profile": "profile1"
+}


### PR DESCRIPTION
- Validate formatted code in builds
- Enable auto-format on save in VS and VS Code
- Remove `dotnet-format` as a tool
