### PR TITLE
TradingPair and historical data improvements

### DIFF
--- a/src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs
+++ b/src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs
@@ -11,6 +11,11 @@ namespace Nerdbank.Cryptocurrencies.Exchanges;
 public record struct ExchangeRate(SecurityAmount Basis, SecurityAmount TradeInterest)
 {
 	/// <summary>
+	/// Gets the trading pair that this exchange rate represents.
+	/// </summary>
+	public TradingPair TradingPair => new(this.Basis.Security, this.TradeInterest.Security);
+
+	/// <summary>
 	/// Gets the cost of the <see cref="Basis"/> security for exactly one unit of <see cref="TradeInterest"/>.
 	/// </summary>
 	public SecurityAmount InBasisAmount => this.Basis.Security.Amount(this.Basis.Amount / this.TradeInterest.Amount);

--- a/src/Nerdbank.Cryptocurrencies/Exchanges/TradingPairEitherOrderEqualityComparer.cs
+++ b/src/Nerdbank.Cryptocurrencies/Exchanges/TradingPairEitherOrderEqualityComparer.cs
@@ -23,8 +23,10 @@ public class TradingPairEitherOrderEqualityComparer : IEqualityComparer<TradingP
 	/// <inheritdoc/>
 	public int GetHashCode(TradingPair obj)
 	{
-		return StringComparer.OrdinalIgnoreCase.Compare(obj.Basis.TickerSymbol, obj.TradeInterest.TickerSymbol) < 0
-			? StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Basis.TickerSymbol)
-			: StringComparer.OrdinalIgnoreCase.GetHashCode(obj.TradeInterest.TickerSymbol);
+		(string first, string second) = StringComparer.OrdinalIgnoreCase.Compare(obj.Basis.TickerSymbol, obj.TradeInterest.TickerSymbol) < 0
+			? (obj.Basis.TickerSymbol, obj.TradeInterest.TickerSymbol)
+			: (obj.TradeInterest.TickerSymbol, obj.Basis.TickerSymbol);
+
+		return HashCode.Combine(StringComparer.OrdinalIgnoreCase.GetHashCode(first), StringComparer.OrdinalIgnoreCase.GetHashCode(second));
 	}
 }

--- a/src/Nerdbank.Cryptocurrencies/Exchanges/TradingPairEitherOrderEqualityComparer.cs
+++ b/src/Nerdbank.Cryptocurrencies/Exchanges/TradingPairEitherOrderEqualityComparer.cs
@@ -6,12 +6,12 @@ namespace Nerdbank.Cryptocurrencies.Exchanges;
 /// <summary>
 /// An equality comparer for <see cref="TradingPair"/> that considers the order of the <see cref="TradingPair.Basis"/> and <see cref="TradingPair.TradeInterest"/> properties to be irrelevant.
 /// </summary>
-internal class TradingPairEitherOrderEqualityComparer : IEqualityComparer<TradingPair>
+public class TradingPairEitherOrderEqualityComparer : IEqualityComparer<TradingPair>
 {
 	/// <summary>
 	/// Gets the singleton instance.
 	/// </summary>
-	internal static readonly TradingPairEitherOrderEqualityComparer Instance = new();
+	public static readonly TradingPairEitherOrderEqualityComparer Instance = new();
 
 	private TradingPairEitherOrderEqualityComparer()
 	{

--- a/src/Nerdbank.Cryptocurrencies/Exchanges/YahooFinance.cs
+++ b/src/Nerdbank.Cryptocurrencies/Exchanges/YahooFinance.cs
@@ -102,8 +102,16 @@ public class YahooFinance : IHistoricalExchangeRateProvider
 				{
 					string[] cells = line.Split(',');
 					DateOnly when = DateOnly.FromDateTime(DateTime.Parse(cells[0], CultureInfo.InvariantCulture));
-					decimal open = decimal.Parse(cells[1], CultureInfo.InvariantCulture);
-					decimal close = decimal.Parse(cells[4], CultureInfo.InvariantCulture);
+					if (!decimal.TryParse(cells[1], CultureInfo.InvariantCulture, out decimal open))
+					{
+						continue;
+					}
+
+					if (!decimal.TryParse(cells[4], CultureInfo.InvariantCulture, out decimal close))
+					{
+						continue;
+					}
+
 					decimal mid = (open + close) / 2;
 					prices.Add(
 						when,

--- a/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt
@@ -84,6 +84,7 @@ Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.Normalized.get -> Nerdbank.Cryp
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.OppositeDirection.get -> Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.TradeInterest.get -> Nerdbank.Cryptocurrencies.SecurityAmount
 Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.TradeInterest.set -> void
+Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate.TradingPair.get -> Nerdbank.Cryptocurrencies.Exchanges.TradingPair
 Nerdbank.Cryptocurrencies.Exchanges.IExchangeRateProvider
 Nerdbank.Cryptocurrencies.Exchanges.IExchangeRateProvider.GetExchangeRateAsync(Nerdbank.Cryptocurrencies.Exchanges.TradingPair tradingPair, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Nerdbank.Cryptocurrencies.Exchanges.ExchangeRate>
 Nerdbank.Cryptocurrencies.Exchanges.IHistoricalExchangeRateProvider
@@ -91,6 +92,9 @@ Nerdbank.Cryptocurrencies.Exchanges.IHistoricalExchangeRateProvider.GetExchangeR
 Nerdbank.Cryptocurrencies.Exchanges.ITradingPairProvider
 Nerdbank.Cryptocurrencies.Exchanges.ITradingPairProvider.FindFirstSupportedTradingPairAsync(Nerdbank.Cryptocurrencies.Security! tradeInterest, System.Collections.Generic.IEnumerable<Nerdbank.Cryptocurrencies.Security!>! acceptableBases, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Nerdbank.Cryptocurrencies.Exchanges.TradingPair?>
 Nerdbank.Cryptocurrencies.Exchanges.ITradingPairProvider.GetAvailableTradingPairsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlySet<Nerdbank.Cryptocurrencies.Exchanges.TradingPair>!>
+Nerdbank.Cryptocurrencies.Exchanges.TradingPairEitherOrderEqualityComparer
+Nerdbank.Cryptocurrencies.Exchanges.TradingPairEitherOrderEqualityComparer.Equals(Nerdbank.Cryptocurrencies.Exchanges.TradingPair x, Nerdbank.Cryptocurrencies.Exchanges.TradingPair y) -> bool
+Nerdbank.Cryptocurrencies.Exchanges.TradingPairEitherOrderEqualityComparer.GetHashCode(Nerdbank.Cryptocurrencies.Exchanges.TradingPair obj) -> int
 Nerdbank.Cryptocurrencies.Security
 Nerdbank.Cryptocurrencies.Security.Amount(decimal amount) -> Nerdbank.Cryptocurrencies.SecurityAmount
 Nerdbank.Cryptocurrencies.Security.Deconstruct(out string! TickerSymbol, out string? Name, out int Precision, out bool IsTestNet) -> void
@@ -198,6 +202,7 @@ static Nerdbank.Cryptocurrencies.Exchanges.TradingPair.operator ==(Nerdbank.Cryp
 static readonly Nerdbank.Cryptocurrencies.Bech32.Bech32m -> Nerdbank.Cryptocurrencies.Bech32!
 static readonly Nerdbank.Cryptocurrencies.Bech32.Original -> Nerdbank.Cryptocurrencies.Bech32!
 static readonly Nerdbank.Cryptocurrencies.Bip32KeyPath.Root -> Nerdbank.Cryptocurrencies.Bip32KeyPath!
+static readonly Nerdbank.Cryptocurrencies.Exchanges.TradingPairEitherOrderEqualityComparer.Instance -> Nerdbank.Cryptocurrencies.Exchanges.TradingPairEitherOrderEqualityComparer!
 static readonly Nerdbank.Cryptocurrencies.Security.ACM -> Nerdbank.Cryptocurrencies.Security!
 static readonly Nerdbank.Cryptocurrencies.Security.ADA -> Nerdbank.Cryptocurrencies.Security!
 static readonly Nerdbank.Cryptocurrencies.Security.AEON -> Nerdbank.Cryptocurrencies.Security!

--- a/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/ExchangeRateTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/ExchangeRateTests.cs
@@ -161,4 +161,11 @@ public class ExchangeRateTests : TestBase
 
 		ExchangeRate Rate(decimal basis, decimal tradeInterest) => new(Security.USD.Amount(basis), Security.ZEC.Amount(tradeInterest));
 	}
+
+	[Fact]
+	public void TradingPair()
+	{
+		ExchangeRate rate = new(Security.USD.Amount(30), Security.ZEC.Amount(1));
+		Assert.Equal(new TradingPair(Security.USD, Security.ZEC), rate.TradingPair);
+	}
 }

--- a/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/TradingPairEitherOrderEqualityComparerTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/TradingPairEitherOrderEqualityComparerTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Nerdbank.Cryptocurrencies.Exchanges;
+
+public class TradingPairEitherOrderEqualityComparerTests
+{
+	[Fact]
+	public void OrderDoesNotMatter()
+	{
+		TradingPair pair1 = new(Security.BTC, Security.USD);
+		TradingPair pair2 = new(Security.USD, Security.BTC);
+		Assert.NotEqual(pair1, pair2);
+		Assert.NotEqual(pair1.GetHashCode(), pair2.GetHashCode());
+
+		Assert.True(TradingPairEitherOrderEqualityComparer.Instance.Equals(pair1, pair2));
+		Assert.Equal(TradingPairEitherOrderEqualityComparer.Instance.GetHashCode(pair1), TradingPairEitherOrderEqualityComparer.Instance.GetHashCode(pair2));
+	}
+
+	[Fact]
+	public void DifferentTradingPairs()
+	{
+		TradingPair pair1 = new(Security.BTC, Security.USD);
+		TradingPair pair2 = new(Security.BTC, Security.EUR);
+		Assert.NotEqual(pair1, pair2);
+		Assert.NotEqual(pair1.GetHashCode(), pair2.GetHashCode());
+
+		Assert.False(TradingPairEitherOrderEqualityComparer.Instance.Equals(pair1, pair2));
+		Assert.NotEqual(TradingPairEitherOrderEqualityComparer.Instance.GetHashCode(pair1), TradingPairEitherOrderEqualityComparer.Instance.GetHashCode(pair2));
+	}
+}


### PR DESCRIPTION
This pull request to the `Nerdbank.Cryptocurrencies` repository includes several changes to improve functionality and accessibility. The most important changes include using `decimal.TryParse` instead of `decimal.Parse` for better error handling, making the `TradingPairEitherOrderEqualityComparer` class and its `Instance` field public, and adding a new property to the `ExchangeRate` struct for easy access to the trading pair.

Main functionality and accessibility changes:

* <a href="diffhunk://#diff-083b029fa64706b41914a708f4d69710be49b4d8dfa406cbe710c81e5d2192baL105-R114">`src/Nerdbank.Cryptocurrencies/Exchanges/YahooFinance.cs`</a>: Updated the `GetExchangeRateAsync` method to use `decimal.TryParse` for better error handling.
* <a href="diffhunk://#diff-4b9d37eebf86d8eac16dfa30b46ece6884c5ba902687fac74dd632d73197b24eL9-R14">`src/Nerdbank.Cryptocurrencies/Exchanges/TradingPairEitherOrderEqualityComparer.cs`</a>: Made the `TradingPairEitherOrderEqualityComparer` class and its `Instance` field public.
* <a href="diffhunk://#diff-62749ed64bf45051f4b4247c9d8185f0ea9435fcf62308420dcd3a5836700aeaR13-R17">`src/Nerdbank.Cryptocurrencies/Exchanges/ExchangeRate.cs`</a>: Added a new property `TradingPair` to the `ExchangeRate` struct for easy access to the trading pair.

Other changes:

* <a href="diffhunk://#diff-c618aa97d2d9e292b9c005541ad54338b43df9c754575ed78826da1c4ada219fR205">`src/Nerdbank.Cryptocurrencies/PublicAPI.Unshipped.txt`</a>: Included changes to improve equality comparison and add a new property for accessing the trading pair in the `TradingPair` and `ExchangeRate` classes. <a href="diffhunk://#diff-c618aa97d2d9e292b9c005541ad54338b43df9c754575ed78826da1c4ada219fR205">[1]</a> <a href="diffhunk://#diff-c618aa97d2d9e292b9c005541ad54338b43df9c754575ed78826da1c4ada219fR87-R97">[2]</a>