### PR TITLE
Add text encoding to sapling diversifiable FVK and IVK

### DIFF
--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -419,11 +419,13 @@ Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.CheckReceiver(Nerdbank.Zcash.
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.DeriveInternal() -> Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey!
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.Equals(Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey? other) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey!
+Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.CheckReceiver(Nerdbank.Zcash.SaplingReceiver receiver) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.CreateDefaultReceiver() -> Nerdbank.Zcash.SaplingReceiver
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.DefaultAddress.get -> Nerdbank.Zcash.SaplingAddress!
+Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryCreateReceiver(ref Nerdbank.Zcash.DiversifierIndex diversifierIndex, out Nerdbank.Zcash.SaplingReceiver? receiver) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey
@@ -842,6 +844,7 @@ static Nerdbank.Zcash.LightWalletClient.SyncProgress.operator !=(Nerdbank.Zcash.
 static Nerdbank.Zcash.LightWalletClient.SyncProgress.operator ==(Nerdbank.Zcash.LightWalletClient.SyncProgress? left, Nerdbank.Zcash.LightWalletClient.SyncProgress? right) -> bool
 static Nerdbank.Zcash.LightWalletClient.SyncResult.operator !=(Nerdbank.Zcash.LightWalletClient.SyncResult? left, Nerdbank.Zcash.LightWalletClient.SyncResult? right) -> bool
 static Nerdbank.Zcash.LightWalletClient.SyncResult.operator ==(Nerdbank.Zcash.LightWalletClient.SyncResult? left, Nerdbank.Zcash.LightWalletClient.SyncResult? right) -> bool
+static Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey? key) -> bool
 static Nerdbank.Zcash.Transaction.operator !=(Nerdbank.Zcash.Transaction? left, Nerdbank.Zcash.Transaction? right) -> bool
 static Nerdbank.Zcash.Transaction.operator ==(Nerdbank.Zcash.Transaction? left, Nerdbank.Zcash.Transaction? right) -> bool
 static Nerdbank.Zcash.Transaction.RecvItem.operator !=(Nerdbank.Zcash.Transaction.RecvItem left, Nerdbank.Zcash.Transaction.RecvItem right) -> bool
@@ -882,6 +885,7 @@ static Nerdbank.Zcash.RawTransaction.SproutFields.operator !=(Nerdbank.Zcash.Raw
 static Nerdbank.Zcash.RawTransaction.SproutFields.operator ==(Nerdbank.Zcash.RawTransaction.SproutFields left, Nerdbank.Zcash.RawTransaction.SproutFields right) -> bool
 static Nerdbank.Zcash.RawTransaction.TransparentFields.operator !=(Nerdbank.Zcash.RawTransaction.TransparentFields left, Nerdbank.Zcash.RawTransaction.TransparentFields right) -> bool
 static Nerdbank.Zcash.RawTransaction.TransparentFields.operator ==(Nerdbank.Zcash.RawTransaction.TransparentFields left, Nerdbank.Zcash.RawTransaction.TransparentFields right) -> bool
+static Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey? key) -> bool
 static Nerdbank.Zcash.Sapling.FullViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.FullViewingKey? key) -> bool
 static Nerdbank.Zcash.Sapling.IncomingViewingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.IncomingViewingKey? key) -> bool
 static Nerdbank.Zcash.SaplingReceiver.UnifiedReceiverTypeCode.get -> byte

--- a/src/Nerdbank.Zcash/Sapling/DiversifiableIncomingViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/DiversifiableIncomingViewingKey.cs
@@ -7,9 +7,10 @@ namespace Nerdbank.Zcash.Sapling;
 /// A viewing key that includes the diversifier key for incoming transactions.
 /// </summary>
 [DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
-public class DiversifiableIncomingViewingKey : IncomingViewingKey, IUnifiedEncodingElement, IIncomingViewingKey
+public class DiversifiableIncomingViewingKey : IncomingViewingKey, IUnifiedEncodingElement, IIncomingViewingKey, IKeyWithTextEncoding
 {
 	private readonly DiversifierKey dk;
+	private string? textEncoding;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="DiversifiableIncomingViewingKey"/> class.
@@ -45,12 +46,45 @@ public class DiversifiableIncomingViewingKey : IncomingViewingKey, IUnifiedEncod
 	/// <inheritdoc/>
 	int IUnifiedEncodingElement.UnifiedDataLength => 32 * 2;
 
+	/// <inheritdoc cref="IKeyWithTextEncoding.TextEncoding" />
+	public new string TextEncoding => this.textEncoding ??= UnifiedViewingKey.Incoming.Create(this).TextEncoding;
+
 	/// <summary>
 	/// Gets the diversification key.
 	/// </summary>
 	internal ref readonly DiversifierKey Dk => ref this.dk;
 
 	private string DebuggerDisplay => this.DefaultAddress;
+
+	/// <inheritdoc cref="IKeyWithTextEncoding.TryDecode(string, out DecodeError?, out string?, out IKeyWithTextEncoding?)"/>
+	static bool IKeyWithTextEncoding.TryDecode(string encoding, [NotNullWhen(false)] out DecodeError? decodeError, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out IKeyWithTextEncoding? key)
+	{
+		if (TryDecode(encoding, out decodeError, out errorMessage, out IncomingViewingKey? ivk))
+		{
+			key = ivk;
+			return true;
+		}
+
+		key = null;
+		return false;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DiversifiableIncomingViewingKey"/> class
+	/// from its <see cref="UnifiedViewingKey"/> encoding.
+	/// </summary>
+	/// <inheritdoc cref="IKeyWithTextEncoding.TryDecode(string, out DecodeError?, out string?, out IKeyWithTextEncoding?)"/>
+	public static bool TryDecode(string encoding, [NotNullWhen(false)] out DecodeError? decodeError, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out DiversifiableIncomingViewingKey? key)
+	{
+		if (UnifiedViewingKey.TryDecode(encoding, out decodeError, out errorMessage, out UnifiedViewingKey? ufvk))
+		{
+			key = ufvk.GetViewingKey<DiversifiableIncomingViewingKey>();
+			return key is not null;
+		}
+
+		key = null;
+		return false;
+	}
 
 	/// <inheritdoc/>
 	int IUnifiedEncodingElement.WriteUnifiedData(Span<byte> destination)

--- a/src/Nerdbank.Zcash/Sapling/FullViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/FullViewingKey.cs
@@ -210,23 +210,6 @@ public class FullViewingKey : IZcashKey, IEquatable<FullViewingKey>, IKeyWithTex
 	/// <summary>
 	/// Gets the raw encoding.
 	/// </summary>
-	/// <param name="rawEncoding">Receives the raw encoding. Must be at least 96 bytes in length.</param>
-	/// <returns>The number of bytes written to <paramref name="rawEncoding"/>. Always 96.</returns>
-	/// <remarks>
-	/// As specified in the <see href="https://zips.z.cash/protocol/protocol.pdf">Zcash protocol spec section 5.6.3.3</see>.
-	/// </remarks>
-	internal int Encode(Span<byte> rawEncoding)
-	{
-		int written = 0;
-		written += this.Ak[..].CopyToRetLength(rawEncoding[written..]);
-		written += this.Nk[..].CopyToRetLength(rawEncoding[written..]);
-		written += this.Ovk[..].CopyToRetLength(rawEncoding[written..]);
-		return written;
-	}
-
-	/// <summary>
-	/// Gets the raw encoding.
-	/// </summary>
 	/// <returns>The raw encoding.</returns>
 	/// <remarks>
 	/// As specified in the <see href="https://zips.z.cash/protocol/protocol.pdf">Zcash protocol spec section 5.6.3.3</see>.
@@ -235,6 +218,23 @@ public class FullViewingKey : IZcashKey, IEquatable<FullViewingKey>, IKeyWithTex
 	{
 		Bytes96 result = default;
 		this.Encode(result);
-		return result;
+		return new(result);
+	}
+
+	/// <summary>
+	/// Gets the raw encoding.
+	/// </summary>
+	/// <param name="rawEncoding">Receives the raw encoding. Must be at least 96 bytes in length.</param>
+	/// <returns>The number of bytes written to <paramref name="rawEncoding"/>. Always 96.</returns>
+	/// <remarks>
+	/// As specified in the <see href="https://zips.z.cash/protocol/protocol.pdf">Zcash protocol spec section 5.6.3.3</see>.
+	/// </remarks>
+	protected int Encode(Span<byte> rawEncoding)
+	{
+		int written = 0;
+		written += this.Ak[..].CopyToRetLength(rawEncoding[written..]);
+		written += this.Nk[..].CopyToRetLength(rawEncoding[written..]);
+		written += this.Ovk[..].CopyToRetLength(rawEncoding[written..]);
+		return written;
 	}
 }

--- a/src/Nerdbank.Zcash/Sapling/IncomingViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/IncomingViewingKey.cs
@@ -168,7 +168,7 @@ public class IncomingViewingKey : IZcashKey, IEquatable<IncomingViewingKey>, IKe
 	/// <remarks>
 	/// As specified in the <see href="https://zips.z.cash/protocol/protocol.pdf">Zcash protocol spec sections 5.6.3.2 and 4.2.2</see>.
 	/// </remarks>
-	internal int Encode(Span<byte> rawEncoding)
+	private int Encode(Span<byte> rawEncoding)
 	{
 		int written = 0;
 		written += this.Ivk[..].CopyToRetLength(rawEncoding[written..]);

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.ExtendedFullViewingKey.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.ExtendedFullViewingKey.cs
@@ -237,7 +237,6 @@ public partial class Zip32HDWallet
 				length += BitUtilities.WriteLE(this.ChildIndex, result[length..]);
 				length += this.ChainCode[..].CopyToRetLength(result[length..]);
 				length += this.FullViewingKey.Encode(result[length..]);
-				length += this.Dk[..].CopyToRetLength(result[length..]);
 				Assumes.True(length == 169);
 				return length;
 			}

--- a/test/Nerdbank.Zcash.Tests/ZcashAccountTests.cs
+++ b/test/Nerdbank.Zcash.Tests/ZcashAccountTests.cs
@@ -334,6 +334,25 @@ public class ZcashAccountTests : TestBase
 	}
 
 	[Fact]
+	public void TryImportAccount_FullViewing_Sapling()
+	{
+		ZcashAccount account = this.ImportAccount(this.DefaultAccount.FullViewing!.Sapling!.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.Null(account.Spending);
+
+		Assert.NotNull(account.FullViewing);
+		Assert.Null(account.FullViewing.Orchard);
+		Assert.NotNull(account.FullViewing.Sapling);
+		Assert.Null(account.FullViewing.Transparent);
+
+		Assert.NotNull(account.IncomingViewing);
+		Assert.Null(account.IncomingViewing.Orchard);
+		Assert.NotNull(account.IncomingViewing.Sapling);
+		Assert.Null(account.IncomingViewing.Transparent);
+	}
+
+	[Fact]
 	public void TryImportAccount_Spending_Transparent()
 	{
 		ZcashAccount account = this.ImportAccount(this.DefaultAccount.Spending!.Transparent!.TextEncoding);
@@ -387,6 +406,22 @@ public class ZcashAccountTests : TestBase
 		Assert.NotNull(account.IncomingViewing);
 		Assert.NotNull(account.IncomingViewing.Orchard);
 		Assert.Null(account.IncomingViewing.Sapling);
+		Assert.Null(account.IncomingViewing.Transparent);
+	}
+
+	[Fact]
+	public void TryImportAccount_IncomingViewing_Sapling()
+	{
+		ZcashAccount account = this.ImportAccount(this.DefaultAccount.IncomingViewing.Sapling!.TextEncoding);
+		Assert.NotNull(account);
+
+		Assert.Null(account.Spending);
+
+		Assert.Null(account.FullViewing);
+
+		Assert.NotNull(account.IncomingViewing);
+		Assert.Null(account.IncomingViewing.Orchard);
+		Assert.NotNull(account.IncomingViewing.Sapling);
 		Assert.Null(account.IncomingViewing.Transparent);
 	}
 


### PR DESCRIPTION
Add text encoding capabilities to sapling diversifiable viewing keys

ZIPs did not prescribe a sapling-specific encoding for these, but Unified viewing keys have since provided a way.