### PR TITLE
Add means to retrieve more birthday height values

### DIFF
--- a/src/Nerdbank.Zcash/LightWalletClient.cs
+++ b/src/Nerdbank.Zcash/LightWalletClient.cs
@@ -122,6 +122,7 @@ public partial class LightWalletClient : IDisposable
 	/// The birthday height is the length of the blockchain when the account was created.
 	/// It serves to reduce initial sync times when this account is imported into another wallet.
 	/// </remarks>
+	/// <seealso cref="GetBirthdayHeights"/>
 	public ulong BirthdayHeight => this.Interop(LightWalletMethods.LightwalletGetBirthdayHeight);
 
 	/// <summary>
@@ -142,6 +143,15 @@ public partial class LightWalletClient : IDisposable
 			() => LightWalletMethods.LightwalletGetBlockHeight(lightWalletServerUrl.AbsoluteUri),
 			cancellationToken));
 	}
+
+	/// <summary>
+	/// Gets the various forms of birthday heights relevant to this account.
+	/// </summary>
+	/// <returns>The birthday heights.</returns>
+	/// <remarks>
+	/// The resulting struct contains fields which may be influenced by the completeness of the sync to the blockchain.
+	/// </remarks>
+	public BirthdayHeights GetBirthdayHeights() => this.Interop(LightWalletMethods.LightwalletGetBirthdayHeights);
 
 	/// <inheritdoc cref="GetLatestBlockHeightAsync(Uri, CancellationToken)"/>
 	public ValueTask<ulong> GetLatestBlockHeightAsync(CancellationToken cancellationToken) => GetLatestBlockHeightAsync(this.serverUrl, cancellationToken);

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -36,6 +36,7 @@ Nerdbank.Zcash.LightWalletClient.BirthdayHeight.get -> ulong
 Nerdbank.Zcash.LightWalletClient.Dispose() -> void
 Nerdbank.Zcash.LightWalletClient.DownloadTransactionsAsync(System.IProgress<Nerdbank.Zcash.LightWalletClient.SyncProgress!>? progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Nerdbank.Zcash.LightWalletClient.SyncResult!>!
 Nerdbank.Zcash.LightWalletClient.DownloadTransactionsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Nerdbank.Zcash.LightWalletClient.SyncResult!>!
+Nerdbank.Zcash.LightWalletClient.GetBirthdayHeights() -> uniffi.LightWallet.BirthdayHeights!
 Nerdbank.Zcash.LightWalletClient.GetDownloadedTransactions(uint startingBlock = 0) -> System.Collections.Generic.List<Nerdbank.Zcash.Transaction!>!
 Nerdbank.Zcash.LightWalletClient.GetLatestBlockHeightAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<ulong>
 Nerdbank.Zcash.LightWalletClient.GetPoolBalances() -> Nerdbank.Zcash.LightWalletClient.PoolBalances

--- a/src/Nerdbank.Zcash/RustBindings/LightWallet.cs
+++ b/src/Nerdbank.Zcash/RustBindings/LightWallet.cs
@@ -433,6 +433,10 @@ static class _UniFFILib {
     );
 
     [DllImport("nerdbank_zcash_rust")]
+    public static extern RustBuffer uniffi_nerdbank_zcash_rust_fn_func_lightwallet_get_birthday_heights(ulong @handle,ref RustCallStatus _uniffi_out_err
+    );
+
+    [DllImport("nerdbank_zcash_rust")]
     public static extern ulong uniffi_nerdbank_zcash_rust_fn_func_lightwallet_get_block_height(RustBuffer @serverUri,ref RustCallStatus _uniffi_out_err
     );
 
@@ -717,6 +721,10 @@ static class _UniFFILib {
     );
 
     [DllImport("nerdbank_zcash_rust")]
+    public static extern ushort uniffi_nerdbank_zcash_rust_checksum_func_lightwallet_get_birthday_heights(
+    );
+
+    [DllImport("nerdbank_zcash_rust")]
     public static extern ushort uniffi_nerdbank_zcash_rust_checksum_func_lightwallet_get_block_height(
     );
 
@@ -792,6 +800,12 @@ static class _UniFFILib {
             var checksum = _UniFFILib.uniffi_nerdbank_zcash_rust_checksum_func_lightwallet_get_birthday_height();
             if (checksum != 29297) {
                 throw new UniffiContractChecksumException($"uniffi.LightWallet: uniffi bindings expected function `uniffi_nerdbank_zcash_rust_checksum_func_lightwallet_get_birthday_height` checksum `29297`, library returned `{checksum}`");
+            }
+        }
+        {
+            var checksum = _UniFFILib.uniffi_nerdbank_zcash_rust_checksum_func_lightwallet_get_birthday_heights();
+            if (checksum != 36095) {
+                throw new UniffiContractChecksumException($"uniffi.LightWallet: uniffi bindings expected function `uniffi_nerdbank_zcash_rust_checksum_func_lightwallet_get_birthday_heights` checksum `36095`, library returned `{checksum}`");
             }
         }
         {
@@ -1031,6 +1045,40 @@ class FfiConverterByteArray: FfiConverterRustBuffer<byte[]> {
     public override void Write(byte[] value, BigEndianStream stream) {
         stream.WriteInt(value.Length);
         stream.WriteBytes(value);
+    }
+}
+
+
+
+public record BirthdayHeights (
+    ulong @originalBirthdayHeight, 
+    ulong @birthdayHeight, 
+    ulong? @rebirthHeight
+) {
+}
+
+class FfiConverterTypeBirthdayHeights: FfiConverterRustBuffer<BirthdayHeights> {
+    public static FfiConverterTypeBirthdayHeights INSTANCE = new FfiConverterTypeBirthdayHeights();
+
+    public override BirthdayHeights Read(BigEndianStream stream) {
+        return new BirthdayHeights(
+            FfiConverterUInt64.INSTANCE.Read(stream),
+            FfiConverterUInt64.INSTANCE.Read(stream),
+            FfiConverterOptionalUInt64.INSTANCE.Read(stream)
+        );
+    }
+
+    public override int AllocationSize(BirthdayHeights value) {
+        return
+            FfiConverterUInt64.INSTANCE.AllocationSize(value.@originalBirthdayHeight) +
+            FfiConverterUInt64.INSTANCE.AllocationSize(value.@birthdayHeight) +
+            FfiConverterOptionalUInt64.INSTANCE.AllocationSize(value.@rebirthHeight);
+    }
+
+    public override void Write(BirthdayHeights value, BigEndianStream stream) {
+            FfiConverterUInt64.INSTANCE.Write(value.@originalBirthdayHeight, stream);
+            FfiConverterUInt64.INSTANCE.Write(value.@birthdayHeight, stream);
+            FfiConverterOptionalUInt64.INSTANCE.Write(value.@rebirthHeight, stream);
     }
 }
 
@@ -1953,6 +2001,14 @@ public static class LightWalletMethods {
         return FfiConverterUInt64.INSTANCE.Lift(
     _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletException.INSTANCE, (ref RustCallStatus _status) =>
     _UniFFILib.uniffi_nerdbank_zcash_rust_fn_func_lightwallet_get_birthday_height(FfiConverterUInt64.INSTANCE.Lower(@handle), ref _status)
+));
+    }
+
+    /// <exception cref="LightWalletException"></exception>
+    public static BirthdayHeights LightwalletGetBirthdayHeights(ulong @handle) {
+        return FfiConverterTypeBirthdayHeights.INSTANCE.Lift(
+    _UniffiHelpers.RustCallWithError(FfiConverterTypeLightWalletException.INSTANCE, (ref RustCallStatus _status) =>
+    _UniFFILib.uniffi_nerdbank_zcash_rust_fn_func_lightwallet_get_birthday_heights(FfiConverterUInt64.INSTANCE.Lower(@handle), ref _status)
 ));
     }
 

--- a/src/nerdbank-zcash-rust/src/ffi.udl
+++ b/src/nerdbank-zcash-rust/src/ffi.udl
@@ -109,13 +109,19 @@ dictionary PoolBalances {
 };
 
 dictionary UserBalances {
-    u64 spendable;
-    u64 immature_change;
-    u64 minimum_fees;
-    u64 immature_income;
-    u64 dust;
-    u64 incoming;
-    u64 incoming_dust;
+	u64 spendable;
+	u64 immature_change;
+	u64 minimum_fees;
+	u64 immature_income;
+	u64 dust;
+	u64 incoming;
+	u64 incoming_dust;
+};
+
+dictionary BirthdayHeights{
+	u64 original_birthday_height;
+	u64 birthday_height;
+	u64? rebirth_height;
 };
 
 namespace LightWallet {
@@ -159,4 +165,7 @@ namespace LightWallet {
 	
 	[Throws=LightWalletError]
 	UserBalances lightwallet_get_user_balances(u64 handle);
+
+	[Throws=LightWalletError]
+	BirthdayHeights lightwallet_get_birthday_heights(u64 handle);
 };

--- a/src/nerdbank-zcash-rust/src/lib.rs
+++ b/src/nerdbank-zcash-rust/src/lib.rs
@@ -9,11 +9,12 @@ mod sapling;
 
 use lightwallet::{
     last_synced_height, lightwallet_deinitialize, lightwallet_get_balances,
-    lightwallet_get_birthday_height, lightwallet_get_block_height, lightwallet_get_transactions,
-    lightwallet_get_user_balances, lightwallet_initialize, lightwallet_initialize_from_disk,
-    lightwallet_send_check_status, lightwallet_send_to_address, lightwallet_sync,
-    lightwallet_sync_interrupt, lightwallet_sync_status, ChainType, Config, LightWalletError,
-    OrchardNote, SaplingNote, SendUpdate, SyncStatus, Transaction, TransactionSendDetail,
-    UserBalances, WalletInfo,
+    lightwallet_get_birthday_height, lightwallet_get_birthday_heights,
+    lightwallet_get_block_height, lightwallet_get_transactions, lightwallet_get_user_balances,
+    lightwallet_initialize, lightwallet_initialize_from_disk, lightwallet_send_check_status,
+    lightwallet_send_to_address, lightwallet_sync, lightwallet_sync_interrupt,
+    lightwallet_sync_status, BirthdayHeights, ChainType, Config, LightWalletError, OrchardNote,
+    SaplingNote, SendUpdate, SyncStatus, Transaction, TransactionSendDetail, UserBalances,
+    WalletInfo,
 };
 use zingolib::lightclient::{PoolBalances, SyncResult};


### PR DESCRIPTION
* Optimized birthday height: the block number on the first block that actually contains a transaction related to this account. A user may create a wallet at block height X, but only receive ZEC for the first time at X+Y, at that point, only X+Y is relevant as a birthday height for that account.
* Rebirth height: The height of the first block that contains a transaction that provides _unspent funds_ (whether as a shielded note or UTXO). This could be provided as a birthday height when importing the account in order to access the full balance of the account, but not necessary download its full history.