### PR TITLE
Auto install uniffi-bindgen if it is not installed

### DIFF
--- a/src/nerdbank-zcash-rust/generate_cs_bindings.ps1
+++ b/src/nerdbank-zcash-rust/generate_cs_bindings.ps1
@@ -2,15 +2,11 @@
 
 <#
 .SYNOPSIS
-    Generate C# bindings for the exported rust functions.
-.PARAMETER InstallPrerequisites
-    Installs uniffi-bindgen-cs.
+    Generate C# bindings for the exported rust functions. If uniffi-bindgen-cs is not installed, it will be installed automatically.
 #>
 
-[CmdletBinding(SupportsShouldProcess = $true)]
-Param(
-    [switch]$InstallPrerequisites
-)
+# Check if uniiffi-bindgen-cs is installed
+[bool]$InstallPrerequisites = $null -eq (Get-Command uniffi-bindgen-cs -ErrorAction SilentlyContinue)
 
 if ($InstallPrerequisites) {
     cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.7.0+v0.25.0


### PR DESCRIPTION
This changes `generate_cs_bindings.ps1` to check if the uniffi-bindgen command is already installed and if not then run the cargo install command to install it. This is being done to simplify the onboarding/new user experience.