### PR TITLE
Rename `WithoutDiversifier` to `WithoutDiversifierKey`

### DIFF
--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -120,6 +120,8 @@ Nerdbank.Zcash.LightWalletClient.SyncResult.SyncResult(bool Success, ulong Lates
 Nerdbank.Zcash.LightWalletClient.SyncResult.SyncResult(Nerdbank.Zcash.LightWalletClient.SyncResult! original) -> void
 Nerdbank.Zcash.LightWalletClient.SyncResult.TotalBlocksScanned.get -> ulong
 Nerdbank.Zcash.LightWalletClient.SyncResult.TotalBlocksScanned.init -> void
+Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.WithoutDiversifierKey.get -> Nerdbank.Zcash.Sapling.FullViewingKey!
+Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.WithoutDiversifierKey.get -> Nerdbank.Zcash.Sapling.IncomingViewingKey!
 Nerdbank.Zcash.Transaction
 Nerdbank.Zcash.Transaction.BlockNumber.get -> uint
 Nerdbank.Zcash.Transaction.BlockNumber.init -> void
@@ -418,14 +420,12 @@ Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.DeriveInternal() -> Nerdbank.
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.Equals(Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey? other) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey!
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
-Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.WithoutDiversifier.get -> Nerdbank.Zcash.Sapling.FullViewingKey!
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.CheckReceiver(Nerdbank.Zcash.SaplingReceiver receiver) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.CreateDefaultReceiver() -> Nerdbank.Zcash.SaplingReceiver
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.DefaultAddress.get -> Nerdbank.Zcash.SaplingAddress!
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryCreateReceiver(ref Nerdbank.Zcash.DiversifierIndex diversifierIndex, out Nerdbank.Zcash.SaplingReceiver? receiver) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
-Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.WithoutDiversifier.get -> Nerdbank.Zcash.Sapling.IncomingViewingKey!
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey.Equals(Nerdbank.Zcash.Sapling.ExpandedSpendingKey? other) -> bool
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey!

--- a/src/Nerdbank.Zcash/Sapling/DiversifiableFullViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/DiversifiableFullViewingKey.cs
@@ -29,7 +29,7 @@ public class DiversifiableFullViewingKey : FullViewingKey, IFullViewingKey, IUni
 	/// <summary>
 	/// Gets the same key, but with the diversifier key removed.
 	/// </summary>
-	public FullViewingKey WithoutDiversifier => new(this.Ak, this.Nk, this.IncomingViewingKey.WithoutDiversifier, this.Ovk);
+	public FullViewingKey WithoutDiversifierKey => new(this.Ak, this.Nk, this.IncomingViewingKey.WithoutDiversifierKey, this.Ovk);
 
 	/// <inheritdoc/>
 	byte IUnifiedEncodingElement.UnifiedTypeCode => UnifiedTypeCodes.Sapling;

--- a/src/Nerdbank.Zcash/Sapling/DiversifiableIncomingViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/DiversifiableIncomingViewingKey.cs
@@ -26,7 +26,7 @@ public class DiversifiableIncomingViewingKey : IncomingViewingKey, IUnifiedEncod
 	/// <summary>
 	/// Gets the same key, but with the diversifier key removed.
 	/// </summary>
-	public IncomingViewingKey WithoutDiversifier => new(this.Ivk, this.Network);
+	public IncomingViewingKey WithoutDiversifierKey => new(this.Ivk, this.Network);
 
 	/// <inheritdoc/>
 	ZcashAddress IIncomingViewingKey.DefaultAddress => this.DefaultAddress;

--- a/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/BinanceUSExchangeTests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/BinanceUSExchangeTests.cs
@@ -16,7 +16,7 @@ public class BinanceUSExchangeTests : TestBase
 	[Trait("RequiresNetwork", "true")]
 	public async Task GetExchangeRateAsync_RespectsPairOrdering(bool fiatSecond)
 	{
-		TradingPair pair = new(Security.USD, Security.ZEC);
+		TradingPair pair = new(Security.USDT, Security.ZEC);
 		if (fiatSecond)
 		{
 			pair = pair.OppositeDirection;

--- a/test/Nerdbank.Zcash.Tests/Sapling/FullViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Sapling/FullViewingKeyTests.cs
@@ -24,12 +24,12 @@ public class FullViewingKeyTests : TestBase
 			: "zviews1hjqajk4hheqry6ye4ygz6jysrh2ekzcyvr5375a9v8vdwz8jt6xz2f0xwjlnsrkd6sra7fl7efjk0lvd3q0mm62n4kkfq0q4laqtygahrnketg356x8q6gjyczcf4wmyhs3mgwt3hktwfre8002u5aunvu6d0rtr";
 		Zip32HDWallet wallet = new(Mnemonic, network);
 		Zip32HDWallet.Sapling.ExtendedSpendingKey account = wallet.CreateSaplingAccount(0);
-		string actual = account.FullViewingKey.WithoutDiversifier.TextEncoding;
+		string actual = account.FullViewingKey.WithoutDiversifierKey.TextEncoding;
 		this.logger.WriteLine(actual);
 		Assert.Equal(expected, actual);
 
 		Assert.True(FullViewingKey.TryDecode(actual, out _, out _, out FullViewingKey? decoded));
-		Assert.Equal(account.FullViewingKey.WithoutDiversifier, decoded);
+		Assert.Equal(account.FullViewingKey.WithoutDiversifierKey, decoded);
 	}
 
 	[Fact]

--- a/test/Nerdbank.Zcash.Tests/Sapling/IncomingViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Sapling/IncomingViewingKeyTests.cs
@@ -25,14 +25,14 @@ public class IncomingViewingKeyTests : TestBase
 			: "zivks1dj9c724gxstqma92fywr3upl2acyu6jg380ml4dlfau8akcuv5rq8xhc3n";
 		Zip32HDWallet wallet = new(Mnemonic, network);
 		Zip32HDWallet.Sapling.ExtendedSpendingKey account = wallet.CreateSaplingAccount(0);
-		string actual = account.FullViewingKey.IncomingViewingKey.WithoutDiversifier.TextEncoding;
+		string actual = account.FullViewingKey.IncomingViewingKey.WithoutDiversifierKey.TextEncoding;
 		this.logger.WriteLine(actual);
 		Assert.Equal(expected, actual);
 
 		Assert.True(IncomingViewingKey.TryDecode(actual, out DecodeError? decodeError, out string? errorMessage, out IncomingViewingKey? key));
 		Assert.Null(decodeError);
 		Assert.Null(errorMessage);
-		Assert.Equal(account.FullViewingKey.IncomingViewingKey.WithoutDiversifier, key);
+		Assert.Equal(account.FullViewingKey.IncomingViewingKey.WithoutDiversifierKey, key);
 	}
 
 	[Fact]


### PR DESCRIPTION
- Fix failing unit test
- Rename `WithoutDiversifier` to `WithoutDiversifierKey`