### PR TITLE
`DefaultAddress` UAs should use a consistent diversifier index

### DIFF
--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -898,6 +898,7 @@ static Nerdbank.Zcash.TxId.Parse(string! txid) -> Nerdbank.Zcash.TxId
 static Nerdbank.Zcash.TxId.Parse(System.ReadOnlySpan<char> txid) -> Nerdbank.Zcash.TxId
 static Nerdbank.Zcash.UnifiedAddress.Create(params Nerdbank.Zcash.ZcashAddress![]! receivers) -> Nerdbank.Zcash.UnifiedAddress!
 static Nerdbank.Zcash.UnifiedAddress.Create(System.Collections.Generic.IReadOnlyCollection<Nerdbank.Zcash.ZcashAddress!>! receivers) -> Nerdbank.Zcash.UnifiedAddress!
+static Nerdbank.Zcash.UnifiedAddress.TryCreate(ref Nerdbank.Zcash.DiversifierIndex startingDiversiferIndex, System.Collections.Generic.IEnumerable<Nerdbank.Zcash.IIncomingViewingKey!>! keys, out Nerdbank.Zcash.UnifiedAddress? address) -> bool
 static Nerdbank.Zcash.UnifiedViewingKey.Decode(string! unifiedViewingKey) -> Nerdbank.Zcash.UnifiedViewingKey!
 static Nerdbank.Zcash.UnifiedViewingKey.Full.Create(params Nerdbank.Zcash.IFullViewingKey![]! viewingKeys) -> Nerdbank.Zcash.UnifiedViewingKey.Full!
 static Nerdbank.Zcash.UnifiedViewingKey.Full.Create(System.Collections.Generic.IEnumerable<Nerdbank.Zcash.IFullViewingKey!>! viewingKeys) -> Nerdbank.Zcash.UnifiedViewingKey.Full!

--- a/src/Nerdbank.Zcash/UnifiedViewingKey.cs
+++ b/src/Nerdbank.Zcash/UnifiedViewingKey.cs
@@ -41,8 +41,17 @@ public abstract class UnifiedViewingKey : IEnumerable<IIncomingViewingKey>, IInc
 	/// <inheritdoc cref="IIncomingViewingKey.DefaultAddress"/>
 	/// <remarks>
 	/// Implemented as described <see href="https://zips.z.cash/zip-0316#deriving-a-unified-address-from-a-uivk">in ZIP-316</see>.
+	/// Specifically, the address will have matching indexes across all receivers.
 	/// </remarks>
-	public UnifiedAddress DefaultAddress => UnifiedAddress.Create(this.viewingKeys.Select(vk => ((IIncomingViewingKey)vk).DefaultAddress).ToArray());
+	public UnifiedAddress DefaultAddress
+	{
+		get
+		{
+			DiversifierIndex index = default;
+			Assumes.True(UnifiedAddress.TryCreate(ref index, this.viewingKeys.Cast<IIncomingViewingKey>(), out UnifiedAddress? address));
+			return address;
+		}
+	}
 
 	/// <inheritdoc/>
 	ZcashAddress IIncomingViewingKey.DefaultAddress => this.DefaultAddress;

--- a/src/Nerdbank.Zcash/ZcashAccount.cs
+++ b/src/Nerdbank.Zcash/ZcashAccount.cs
@@ -240,8 +240,17 @@ public class ZcashAccount
 	/// <param name="index">Receives the diversifier index used to construct this address.</param>
 	/// <returns><see langword="true" /> if the address came from this account and the diversifier could be decrypted; otherwise <see langword="false" />.</returns>
 	/// <remarks>
+	/// <para>
 	/// If the <paramref name="address"/> contains multiple diversifiable receivers,
 	/// the diversifier index will only be reported from this method if it matches for all such receivers.
+	/// </para>
+	/// <para>
+	/// Because there is no constant time path from transparent receiver to its address index,
+	/// <em>transparent receivers are ignored</em> by this method.
+	/// Callers that are interested in the address index of the <see cref="TransparentP2PKHReceiver"/>
+	/// component of an address should use <see cref="Zip32HDWallet.Transparent.ExtendedViewingKey.TryGetAddressIndex(TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)"/>
+	/// directly to search for a match.
+	/// </para>
 	/// </remarks>
 	public bool TryGetDiversifierIndex(ZcashAddress address, [NotNullWhen(true)] out DiversifierIndex? index)
 	{

--- a/test/Nerdbank.Zcash.Tests/UnifiedViewingKeyTests.cs
+++ b/test/Nerdbank.Zcash.Tests/UnifiedViewingKeyTests.cs
@@ -445,7 +445,8 @@ public class UnifiedViewingKeyTests : TestBase
 		Zip32HDWallet wallet = new(Mnemonic, ZcashNetwork.MainNet);
 		SaplingSK saplingSK = wallet.CreateSaplingAccount();
 		OrchardSK orchardSK = wallet.CreateOrchardAccount();
-		UnifiedAddress ua = UnifiedAddress.Create(saplingSK.DefaultAddress, orchardSK.DefaultAddress);
+		DiversifierIndex index = default;
+		Assert.True(UnifiedAddress.TryCreate(ref index, [saplingSK, orchardSK], out UnifiedAddress? ua));
 
 		UnifiedViewingKey.Full ufvk = UnifiedViewingKey.Full.Create(saplingSK, orchardSK);
 		Assert.Equal(ua, ufvk.DefaultAddress);

--- a/test/Nerdbank.Zcash.Tests/ZcashAccountTests.cs
+++ b/test/Nerdbank.Zcash.Tests/ZcashAccountTests.cs
@@ -123,6 +123,18 @@ public class ZcashAccountTests : TestBase
 		Assert.Null(actualIndex);
 	}
 
+	/// <summary>
+	/// Verifies that for an account with a sapling key that doesn't produce a valid diversifier at index 0,
+	/// the default UA uses the same index for all receivers, as required by ZIP-316.
+	/// </summary>
+	[Fact]
+	public void DefaultAddress_WithInvalidSaplingKeyAt0_HasConsistentIndexes()
+	{
+		// The particular mnemonic used here has a sapling key that doesn't produce a valid diversifier at index 0.
+		ZcashAccount account = new(new Zip32HDWallet(Mnemonic, ZcashNetwork.MainNet));
+		UnifiedAddressTests.AssertAddressIndex(account, new DiversifierIndex(3), account.DefaultAddress);
+	}
+
 	[Fact]
 	public void GetTransparentAddress()
 	{


### PR DESCRIPTION
As part of this, we add an API to make it easy to construct a `UnifiedAddress` using keys instead of addresses, so that all the indexes match.

This improves ZIP-316 compliance, which for contestable reasons [requires all receivers in a UA to have matching indexes][ZIP316].

Note that `UnifiedAddress.Create` can still combine arbitrary addresses. It's only the `TryCreate` method that guarantees matching indexes in the result. But since `TryCreate` is now how `UnifiedViewingKey.DefaultAddress`  is implemented, default addresses will now conform to ZIP-316.
Note also that `ZcashAccount.GetDiversifiedAddress` already generated compliant UAs (and always lack a transparent component).

[ZIP316]: https://github.com/zcash/zips/blob/fee271c03da36836c58e649d9674fa430e343810/zip-0316.rst#L690-L692