### PR TITLE
Merge latest Library.Template

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.2.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.25.1" />
+    <PackageVersion Include="Google.Protobuf" Version="3.25.2" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.60.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.60.0" />
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />


### PR DESCRIPTION
- Format init.ps1
- Bump dotnet-coverage from 17.10.1 to 17.10.2 (#250)
