### PR TITLE
Stop embedding the sapling parameters

### DIFF
--- a/src/nerdbank-zcash-rust/Cargo.lock
+++ b/src/nerdbank-zcash-rust/Cargo.lock
@@ -1131,6 +1131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "known-folders"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4397c789f2709d23cfcb703b316e0766a8d4b17db2d47b0ab096ef6047cae1d8"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1258,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "minreq"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3371dfc7b772c540da1380123674a8e20583aca99907087d990ca58cf44203"
+dependencies = [
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1299,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "matches",
+ "minreq",
  "orchard",
  "pasta_curves",
  "prost",
@@ -2673,56 +2696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "wagyu-zcash-parameters"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c904628658374e651288f000934c33ef738b2d8b3e65d4100b70b395dbe2bb"
-dependencies = [
- "wagyu-zcash-parameters-1",
- "wagyu-zcash-parameters-2",
- "wagyu-zcash-parameters-3",
- "wagyu-zcash-parameters-4",
- "wagyu-zcash-parameters-5",
- "wagyu-zcash-parameters-6",
-]
-
-[[package]]
-name = "wagyu-zcash-parameters-1"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bf2e21bb027d3f8428c60d6a720b54a08bf6ce4e6f834ef8e0d38bb5695da8"
-
-[[package]]
-name = "wagyu-zcash-parameters-2"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a616ab2e51e74cc48995d476e94de810fb16fc73815f390bf2941b046cc9ba2c"
-
-[[package]]
-name = "wagyu-zcash-parameters-3"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14da1e2e958ff93c0830ee68e91884069253bf3462a67831b02b367be75d6147"
-
-[[package]]
-name = "wagyu-zcash-parameters-4"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f058aeef03a2070e8666ffb5d1057d8bb10313b204a254a6e6103eb958e9a6d6"
-
-[[package]]
-name = "wagyu-zcash-parameters-5"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffe916b30e608c032ae1b734f02574a3e12ec19ab5cc5562208d679efe4969d"
-
-[[package]]
-name = "wagyu-zcash-parameters-6"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b6d5a78adc3e8f198e9cd730f219a695431467f7ec29dcfc63ade885feebe1"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,6 +2984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
 name = "zcash_address"
 version = "0.3.1"
 dependencies = [
@@ -3184,13 +3163,16 @@ dependencies = [
  "bls12_381",
  "document-features",
  "group",
+ "home",
  "jubjub",
+ "known-folders",
  "lazy_static",
+ "minreq",
  "rand_core",
  "redjubjub",
  "sapling-crypto",
  "tracing",
- "wagyu-zcash-parameters",
+ "xdg",
  "zcash_primitives",
 ]
 

--- a/src/nerdbank-zcash-rust/Cargo.toml
+++ b/src/nerdbank-zcash-rust/Cargo.toml
@@ -20,6 +20,7 @@ hdwallet = { path = "../../external/hdwallet" }
 http = "0.2"
 jubjub = "0.10"
 lazy_static = "1.4"
+minreq = "2.11.0"
 orchard = "0.7.0"
 pasta_curves = "0.5"
 prost = "0.12"
@@ -57,7 +58,8 @@ zcash_keys = { path = "../../external/librustzcash/zcash_keys", features = [
 	"test-dependencies",
 ] }
 zcash_proofs = { path = "../../external/librustzcash/zcash_proofs", features = [
-	"bundled-prover",
+	"download-params",
+	"local-prover",
 	"multicore",
 ], default-features = false }
 zeroize = "1.7.0"

--- a/src/nerdbank-zcash-rust/src/error.rs
+++ b/src/nerdbank-zcash-rust/src/error.rs
@@ -41,6 +41,8 @@ pub enum Error {
 
     Io(std::io::Error),
 
+    Minreq(minreq::Error),
+
     Internal(String),
 
     Sqlite(rusqlite::Error),
@@ -112,6 +114,7 @@ impl std::fmt::Display for Error {
             Error::InvalidArgument(e) => e.fmt(f),
             Error::Anyhow(e) => e.fmt(f),
             Error::SendFailed { code, reason } => write!(f, "Send failed: {}: {}", code, reason),
+            Error::Minreq(e) => e.fmt(f),
         }
     }
 }
@@ -204,6 +207,12 @@ impl From<memo::Error> for Error {
 impl From<Zip321Error> for Error {
     fn from(e: Zip321Error) -> Self {
         Error::Zip321(e)
+    }
+}
+
+impl From<minreq::Error> for Error {
+    fn from(value: minreq::Error) -> Self {
+        Error::Minreq(value)
     }
 }
 

--- a/src/nerdbank-zcash-rust/src/lib.rs
+++ b/src/nerdbank-zcash-rust/src/lib.rs
@@ -11,6 +11,7 @@ mod grpc;
 mod interop;
 mod lightclient;
 mod orchard;
+mod prover;
 mod resilience;
 mod sapling;
 mod send;

--- a/src/nerdbank-zcash-rust/src/prover.rs
+++ b/src/nerdbank-zcash-rust/src/prover.rs
@@ -1,0 +1,11 @@
+use zcash_proofs::{download_sapling_parameters, prover::LocalTxProver};
+
+use crate::error::Error;
+
+pub(crate) fn get_prover() -> Result<LocalTxProver, Error> {
+    let parameter_paths = download_sapling_parameters(None)?;
+    Ok(LocalTxProver::new(
+        &parameter_paths.spend,
+        &parameter_paths.output,
+    ))
+}

--- a/src/nerdbank-zcash-rust/src/send.rs
+++ b/src/nerdbank-zcash-rust/src/send.rs
@@ -22,9 +22,11 @@ use zcash_primitives::{
         components::amount::NonNegativeAmount, fees::zip317::FeeRule, Transaction, TxId,
     },
 };
-use zcash_proofs::prover::LocalTxProver;
 
-use crate::{backing_store::Db, error::Error, grpc::get_client, interop::TransactionSendDetail};
+use crate::{
+    backing_store::Db, error::Error, grpc::get_client, interop::TransactionSendDetail,
+    prover::get_prover,
+};
 
 #[derive(Debug)]
 pub struct SendTransactionResult {
@@ -42,7 +44,7 @@ pub async fn send_transaction<P: AsRef<Path>>(
 ) -> Result<SendTransactionResult, Error> {
     let mut db = Db::init(data_file, network)?;
 
-    let prover = LocalTxProver::bundled();
+    let prover = get_prover()?;
 
     // TODO: revise this to a smarter change strategy that avoids unnecessarily crossing the turnstile.
     let input_selector = GreedyInputSelector::new(

--- a/src/nerdbank-zcash-rust/src/shield.rs
+++ b/src/nerdbank-zcash-rust/src/shield.rs
@@ -19,12 +19,12 @@ use zcash_primitives::{
     transaction::fees::zip317::{FeeRule, MINIMUM_FEE},
     zip32::AccountId,
 };
-use zcash_proofs::prover::LocalTxProver;
 
 use crate::{
     backing_store::Db,
     error::Error,
     interop::{DbInit, TransparentNote},
+    prover::get_prover,
     send::{transmit_transaction, SendTransactionResult},
     sql_statements::GET_UNSPENT_TRANSPARENT_NOTES,
 };
@@ -41,8 +41,7 @@ pub async fn shield_funds_at_address<P: AsRef<Path>>(
     // We want to be able to shield as soon as UTXOs appear in the mempool.
     let min_confirmations = 0;
 
-    let prover = LocalTxProver::bundled();
-
+    let prover = get_prover()?;
     let input_selector = GreedyInputSelector::new(
         SingleOutputChangeStrategy::new(FeeRule::standard(), None),
         Default::default(),


### PR DESCRIPTION
This will dramatically reduce the size of the nuget package, since each of several targeted builds of the rust library had previously bundled their own copy of the parameters.

Alternatively to address the nupkg size problem (#235), we could download the parameters and include them as their own payload in the nupkg so that all runtime binaries can share one copy.

Fixes #235