### PR TITLE
Add option to 'stay in sync' with blockchain

### DIFF
--- a/src/Nerdbank.Zcash.Cli/Strings.resx
+++ b/src/Nerdbank.Zcash.Cli/Strings.resx
@@ -132,6 +132,9 @@
   <data name="BirthdayHeightOptionDescription" xml:space="preserve">
     <value>Forces a particular birthday height to be recorded in the new account. By default this will be the current blockchain length if in online mode.</value>
   </data>
+  <data name="ContinuallyOptionDescription" xml:space="preserve">
+    <value>Download the blockchain continually, watching for new blocks as they are added.</value>
+  </data>
   <data name="HistoryCommandDescription" xml:space="preserve">
     <value>List transactions from the blockchain belonging to this wallet.</value>
   </data>

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -66,8 +66,7 @@ Nerdbank.Zcash.LightWalletClient.BirthdayHeights.OriginalBirthdayHeight.set -> v
 Nerdbank.Zcash.LightWalletClient.BirthdayHeights.RebirthHeight.get -> ulong?
 Nerdbank.Zcash.LightWalletClient.BirthdayHeights.RebirthHeight.set -> void
 Nerdbank.Zcash.LightWalletClient.Dispose() -> void
-Nerdbank.Zcash.LightWalletClient.DownloadTransactionsAsync(System.IProgress<Nerdbank.Zcash.LightWalletClient.SyncProgress!>? statusUpdates, System.IProgress<System.Collections.Generic.IReadOnlyCollection<Nerdbank.Zcash.Transaction!>!>? discoveredTransactions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Nerdbank.Zcash.LightWalletClient.SyncResult!>!
-Nerdbank.Zcash.LightWalletClient.DownloadTransactionsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Nerdbank.Zcash.LightWalletClient.SyncResult!>!
+Nerdbank.Zcash.LightWalletClient.DownloadTransactionsAsync(System.IProgress<Nerdbank.Zcash.LightWalletClient.SyncProgress!>? statusUpdates, System.IProgress<System.Collections.Generic.IReadOnlyCollection<Nerdbank.Zcash.Transaction!>!>? discoveredTransactions, bool continually, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Nerdbank.Zcash.LightWalletClient.SyncProgress!>!
 Nerdbank.Zcash.LightWalletClient.GetAccounts() -> System.Collections.Generic.IEnumerable<Nerdbank.Zcash.ZcashAccount!>!
 Nerdbank.Zcash.LightWalletClient.GetBalances(Nerdbank.Zcash.ZcashAccount! account) -> Nerdbank.Zcash.AccountBalances!
 Nerdbank.Zcash.LightWalletClient.GetBirthdayHeights(Nerdbank.Zcash.ZcashAccount! account) -> Nerdbank.Zcash.LightWalletClient.BirthdayHeights
@@ -110,23 +109,20 @@ Nerdbank.Zcash.LightWalletClient.ShieldedPoolBalance.UnverifiedBalance.set -> vo
 Nerdbank.Zcash.LightWalletClient.ShieldedPoolBalance.VerifiedBalance.get -> decimal
 Nerdbank.Zcash.LightWalletClient.ShieldedPoolBalance.VerifiedBalance.set -> void
 Nerdbank.Zcash.LightWalletClient.SyncProgress
-Nerdbank.Zcash.LightWalletClient.SyncProgress.Current.get -> ulong
-Nerdbank.Zcash.LightWalletClient.SyncProgress.Current.init -> void
-Nerdbank.Zcash.LightWalletClient.SyncProgress.Deconstruct(out ulong Current, out ulong Total, out string? LastError) -> void
+Nerdbank.Zcash.LightWalletClient.SyncProgress.CurrentStep.get -> ulong
+Nerdbank.Zcash.LightWalletClient.SyncProgress.CurrentStep.init -> void
+Nerdbank.Zcash.LightWalletClient.SyncProgress.Deconstruct(out uint? LastFullyScannedBlock, out uint TipHeight, out ulong CurrentStep, out ulong TotalSteps, out string? LastError) -> void
 Nerdbank.Zcash.LightWalletClient.SyncProgress.LastError.get -> string?
 Nerdbank.Zcash.LightWalletClient.SyncProgress.LastError.init -> void
+Nerdbank.Zcash.LightWalletClient.SyncProgress.LastFullyScannedBlock.get -> uint?
+Nerdbank.Zcash.LightWalletClient.SyncProgress.LastFullyScannedBlock.init -> void
+Nerdbank.Zcash.LightWalletClient.SyncProgress.PercentComplete.get -> double
 Nerdbank.Zcash.LightWalletClient.SyncProgress.SyncProgress(Nerdbank.Zcash.LightWalletClient.SyncProgress! original) -> void
-Nerdbank.Zcash.LightWalletClient.SyncProgress.SyncProgress(ulong Current, ulong Total, string? LastError) -> void
-Nerdbank.Zcash.LightWalletClient.SyncProgress.Total.get -> ulong
-Nerdbank.Zcash.LightWalletClient.SyncProgress.Total.init -> void
-Nerdbank.Zcash.LightWalletClient.SyncResult
-Nerdbank.Zcash.LightWalletClient.SyncResult.Deconstruct(out bool Success, out ulong LatestBlock) -> void
-Nerdbank.Zcash.LightWalletClient.SyncResult.LatestBlock.get -> ulong
-Nerdbank.Zcash.LightWalletClient.SyncResult.LatestBlock.init -> void
-Nerdbank.Zcash.LightWalletClient.SyncResult.Success.get -> bool
-Nerdbank.Zcash.LightWalletClient.SyncResult.Success.init -> void
-Nerdbank.Zcash.LightWalletClient.SyncResult.SyncResult(bool Success, ulong LatestBlock) -> void
-Nerdbank.Zcash.LightWalletClient.SyncResult.SyncResult(Nerdbank.Zcash.LightWalletClient.SyncResult! original) -> void
+Nerdbank.Zcash.LightWalletClient.SyncProgress.SyncProgress(uint? LastFullyScannedBlock, uint TipHeight, ulong CurrentStep, ulong TotalSteps, string? LastError) -> void
+Nerdbank.Zcash.LightWalletClient.SyncProgress.TipHeight.get -> uint
+Nerdbank.Zcash.LightWalletClient.SyncProgress.TipHeight.init -> void
+Nerdbank.Zcash.LightWalletClient.SyncProgress.TotalSteps.get -> ulong
+Nerdbank.Zcash.LightWalletClient.SyncProgress.TotalSteps.init -> void
 Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance
 Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.Balance.get -> decimal
 Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.Balance.set -> void
@@ -730,9 +726,6 @@ override Nerdbank.Zcash.LightWalletClient.ShieldedPoolBalance.GetHashCode() -> i
 override Nerdbank.Zcash.LightWalletClient.SyncProgress.Equals(object? obj) -> bool
 override Nerdbank.Zcash.LightWalletClient.SyncProgress.GetHashCode() -> int
 override Nerdbank.Zcash.LightWalletClient.SyncProgress.ToString() -> string!
-override Nerdbank.Zcash.LightWalletClient.SyncResult.Equals(object? obj) -> bool
-override Nerdbank.Zcash.LightWalletClient.SyncResult.GetHashCode() -> int
-override Nerdbank.Zcash.LightWalletClient.SyncResult.ToString() -> string!
 override Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.GetHashCode() -> int
 override Nerdbank.Zcash.Memo.ToString() -> string!
 override Nerdbank.Zcash.Orchard.FullViewingKey.Equals(object? obj) -> bool
@@ -830,8 +823,6 @@ static Nerdbank.Zcash.LightWalletClient.ShieldedPoolBalance.operator !=(Nerdbank
 static Nerdbank.Zcash.LightWalletClient.ShieldedPoolBalance.operator ==(Nerdbank.Zcash.LightWalletClient.ShieldedPoolBalance left, Nerdbank.Zcash.LightWalletClient.ShieldedPoolBalance right) -> bool
 static Nerdbank.Zcash.LightWalletClient.SyncProgress.operator !=(Nerdbank.Zcash.LightWalletClient.SyncProgress? left, Nerdbank.Zcash.LightWalletClient.SyncProgress? right) -> bool
 static Nerdbank.Zcash.LightWalletClient.SyncProgress.operator ==(Nerdbank.Zcash.LightWalletClient.SyncProgress? left, Nerdbank.Zcash.LightWalletClient.SyncProgress? right) -> bool
-static Nerdbank.Zcash.LightWalletClient.SyncResult.operator !=(Nerdbank.Zcash.LightWalletClient.SyncResult? left, Nerdbank.Zcash.LightWalletClient.SyncResult? right) -> bool
-static Nerdbank.Zcash.LightWalletClient.SyncResult.operator ==(Nerdbank.Zcash.LightWalletClient.SyncResult? left, Nerdbank.Zcash.LightWalletClient.SyncResult? right) -> bool
 static Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.operator !=(Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance left, Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance right) -> bool
 static Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance.operator ==(Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance left, Nerdbank.Zcash.LightWalletClient.TransparentPoolBalance right) -> bool
 static Nerdbank.Zcash.LightWalletServers.GetDefaultServer(Nerdbank.Zcash.ZcashNetwork network) -> System.Uri!
@@ -963,10 +954,6 @@ virtual Nerdbank.Zcash.LightWalletClient.SyncProgress.<Clone>$() -> Nerdbank.Zca
 virtual Nerdbank.Zcash.LightWalletClient.SyncProgress.EqualityContract.get -> System.Type!
 virtual Nerdbank.Zcash.LightWalletClient.SyncProgress.Equals(Nerdbank.Zcash.LightWalletClient.SyncProgress? other) -> bool
 virtual Nerdbank.Zcash.LightWalletClient.SyncProgress.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Nerdbank.Zcash.LightWalletClient.SyncResult.<Clone>$() -> Nerdbank.Zcash.LightWalletClient.SyncResult!
-virtual Nerdbank.Zcash.LightWalletClient.SyncResult.EqualityContract.get -> System.Type!
-virtual Nerdbank.Zcash.LightWalletClient.SyncResult.Equals(Nerdbank.Zcash.LightWalletClient.SyncResult? other) -> bool
-virtual Nerdbank.Zcash.LightWalletClient.SyncResult.PrintMembers(System.Text.StringBuilder! builder) -> bool
 virtual Nerdbank.Zcash.Transaction.<Clone>$() -> Nerdbank.Zcash.Transaction!
 virtual Nerdbank.Zcash.Transaction.EqualityContract.get -> System.Type!
 virtual Nerdbank.Zcash.Transaction.Equals(Nerdbank.Zcash.Transaction? other) -> bool

--- a/src/nerdbank-zcash-rust/src/ffi.udl
+++ b/src/nerdbank-zcash-rust/src/ffi.udl
@@ -64,10 +64,6 @@ dictionary BirthdayHeights {
 	u32? rebirth_height;
 };
 
-dictionary SyncResult {
-	u64 latest_block;
-};
-
 dictionary DbInit {
 	string data_file;
 	ChainType network;
@@ -78,8 +74,10 @@ dictionary SendTransactionResult {
 };
 
 dictionary SyncUpdateData {
-	u64 current;
-	u64 total;
+	u32? last_fully_scanned_block;
+	u32 tip_height;
+	u64 current_step;
+	u64 total_steps;
 	string? last_error;
 };
 
@@ -115,8 +113,10 @@ namespace LightWallet {
 	[Throws=LightWalletError]
 	u32? get_sync_height(DbInit config);
 
+	/// Downloads blocks from the blockchain, scans them for transactions, and updates the database.
+	/// If `continually` is `true`, this function will never exit unless cancellation is signaled.
 	[Throws=LightWalletError]
-	SyncResult sync(DbInit config, string uri, SyncUpdate? progress, CancellationSource? cancellation);
+	SyncUpdateData sync(DbInit config, string uri, SyncUpdate? progress, boolean continually, CancellationSource? cancellation);
 
 	[Throws=LightWalletError]
 	boolean disconnect_server(string uri);

--- a/src/nerdbank-zcash-rust/src/interop.rs
+++ b/src/nerdbank-zcash-rust/src/interop.rs
@@ -60,8 +60,10 @@ impl From<uniffi::UnexpectedUniFFICallbackError> for LightWalletError {
 
 #[derive(Debug, Clone)]
 pub struct SyncUpdateData {
-    pub current: u64,
-    pub total: u64,
+    pub last_fully_scanned_block: Option<u32>,
+    pub tip_height: u32,
+    pub current_step: u64,
+    pub total_steps: u64,
     pub last_error: Option<String>,
 }
 
@@ -189,11 +191,6 @@ impl From<Error> for LightWalletError {
             },
         }
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct SyncResult {
-    pub latest_block: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -355,8 +352,9 @@ pub fn sync(
     config: DbInit,
     uri: String,
     progress: Option<Box<dyn SyncUpdate>>,
+    continually: bool,
     cancellation: Option<Box<dyn CancellationSource>>,
-) -> Result<SyncResult, LightWalletError> {
+) -> Result<SyncUpdateData, LightWalletError> {
     use crate::sync::sync;
     let uri: Uri = uri.parse()?;
     let cancellation_token = get_cancellation_token(cancellation)?;
@@ -365,6 +363,7 @@ pub fn sync(
             uri,
             config.data_file,
             progress,
+            continually,
             cancellation_token.0.clone(),
         )
         .await?)

--- a/src/nerdbank-zcash-rust/src/lib.rs
+++ b/src/nerdbank-zcash-rust/src/lib.rs
@@ -28,5 +28,5 @@ use interop::{
     get_birthday_heights, get_block_height, get_sync_height, get_transactions,
     get_unshielded_utxos, get_user_balances, init, send, shield, sync, AccountInfo,
     CancellationSource, ChainType, DbInit, LightWalletError, SendTransactionResult, ShieldedNote,
-    SyncResult, SyncUpdate, SyncUpdateData, Transaction, TransactionSendDetail, TransparentNote,
+    SyncUpdate, SyncUpdateData, Transaction, TransactionSendDetail, TransparentNote,
 };

--- a/src/nerdbank-zcash-rust/src/resilience.rs
+++ b/src/nerdbank-zcash-rust/src/resilience.rs
@@ -22,11 +22,9 @@ pub(crate) async fn webrequest_with_logged_retry<
     let mut failure_count = 0;
     loop {
         let result = select! {
-            r = delegate() => r,
-            _ = cancellation_token.cancelled() => {
-                return Err(Status::cancelled("Request cancelled"));
-            },
-        };
+            r = delegate() => Ok(r),
+            _ = cancellation_token.cancelled() => Err(Status::cancelled("Request cancelled")),
+        }?;
         match result {
             Ok(result) => return Ok(result),
             Err(status) => {
@@ -54,11 +52,9 @@ pub(crate) async fn webrequest_with_retry<
     let mut failure_count = 0;
     loop {
         let result = select! {
-            r = delegate() => r,
-            _ = cancellation_token.cancelled() => {
-                return Err(Status::cancelled("Request cancelled"));
-            },
-        };
+            r = delegate() => Ok(r),
+            _ = cancellation_token.cancelled() => Err(Status::cancelled("Request cancelled")),
+        }?;
         match result {
             Ok(result) => return Ok(result),
             Err(status) => {

--- a/src/nerdbank-zcash-rust/src/send.rs
+++ b/src/nerdbank-zcash-rust/src/send.rs
@@ -131,6 +131,7 @@ mod tests {
             setup.server_uri.clone(),
             setup.data_file.clone(),
             None,
+            false,
             CancellationToken::new(),
         )
         .await

--- a/test/Nerdbank.Zcash.Tests/LightWalletClientTests.cs
+++ b/test/Nerdbank.Zcash.Tests/LightWalletClientTests.cs
@@ -93,14 +93,15 @@ public class LightWalletClientTests : TestBase, IDisposable, IAsyncLifetime
 	[Fact]
 	public async Task DownloadTransactionsAsync()
 	{
-		LightWalletClient.SyncResult result = await this.client.DownloadTransactionsAsync(
+		LightWalletClient.SyncProgress result = await this.client.DownloadTransactionsAsync(
 			new Progress<LightWalletClient.SyncProgress>(p =>
 			{
 				this.logger.WriteLine($"Sync progress update: {p}");
 			}),
 			null,
+			continually: false,
 			this.TimeoutToken);
-		this.logger.WriteLine($"Sync succeeded: {result.Success}. Scanned to block {result.LatestBlock}.");
+		this.logger.WriteLine($"Sync succeeded. Scanned to block {result.LastFullyScannedBlock}.");
 	}
 
 	[Fact]


### PR DESCRIPTION
This removes the client's need to poll on a timer. We utilize the LWD server's gRPC API to know when a new block has been mined.