### PR TITLE
Initialize fees for (nearly) all transactions

### DIFF
--- a/src/Nerdbank.Zcash.Cli/HistoryCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/HistoryCommand.cs
@@ -58,7 +58,7 @@ internal class HistoryCommand : SyncFirstCommandBase
 			}
 		}
 
-		if (tx.IsOutgoing)
+		if (!tx.IsIncoming)
 		{
 			console.WriteLine($"{indentation} -{tx.Fee,13:N8} transaction fee");
 		}

--- a/src/Nerdbank.Zcash/LightWalletClient.cs
+++ b/src/Nerdbank.Zcash/LightWalletClient.cs
@@ -430,7 +430,7 @@ public partial class LightWalletClient : IDisposable
 	/// </summary>
 	/// <param name="t">The uniffi transaction to copy data from.</param>
 	private static Transaction CreateTransaction(uniffi.LightWallet.Transaction t)
-		=> new(new TxId(t.txid), t.minedHeight, t.expiredUnmined, t.blockTime, ZatsToZEC(t.accountBalanceDelta), ZatsToZEC(t.fee), [.. t.outgoing.Select(CreateSendItem)], [.. t.incomingShielded.Select(CreateRecvItem), .. t.incomingTransparent.Select(CreateRecvItem)]);
+		=> new(new TxId(t.txid), t.minedHeight, t.expiredUnmined, t.blockTime, ZatsToZEC(t.accountBalanceDelta), t.fee.HasValue ? ZatsToZEC(t.fee.Value) : null, [.. t.outgoing.Select(CreateSendItem)], [.. t.incomingShielded.Select(CreateRecvItem), .. t.incomingTransparent.Select(CreateRecvItem)]);
 
 	/// <summary>
 	/// Wraps an interop invocation in a <see langword="try" /> block and wraps

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -411,7 +411,7 @@ Nerdbank.Zcash.Transaction
 Nerdbank.Zcash.Transaction.ExpiredUnmined.get -> bool
 Nerdbank.Zcash.Transaction.Fee.get -> decimal
 Nerdbank.Zcash.Transaction.Incoming.get -> System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.RecvItem>
-Nerdbank.Zcash.Transaction.IsOutgoing.get -> bool
+Nerdbank.Zcash.Transaction.IsIncoming.get -> bool
 Nerdbank.Zcash.Transaction.MinedHeight.get -> uint?
 Nerdbank.Zcash.Transaction.NetChange.get -> decimal
 Nerdbank.Zcash.Transaction.Outgoing.get -> System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.SendItem>

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -409,7 +409,7 @@ Nerdbank.Zcash.SproutReceiver.SproutReceiver() -> void
 Nerdbank.Zcash.SproutReceiver.SproutReceiver(System.ReadOnlySpan<byte> apk, System.ReadOnlySpan<byte> pkEnc) -> void
 Nerdbank.Zcash.Transaction
 Nerdbank.Zcash.Transaction.ExpiredUnmined.get -> bool
-Nerdbank.Zcash.Transaction.Fee.get -> decimal
+Nerdbank.Zcash.Transaction.Fee.get -> decimal?
 Nerdbank.Zcash.Transaction.Incoming.get -> System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.RecvItem>
 Nerdbank.Zcash.Transaction.IsIncoming.get -> bool
 Nerdbank.Zcash.Transaction.MinedHeight.get -> uint?
@@ -442,7 +442,7 @@ Nerdbank.Zcash.Transaction.SendItem.SendItem(Nerdbank.Zcash.ZcashAddress! ToAddr
 Nerdbank.Zcash.Transaction.SendItem.ToAddress.get -> Nerdbank.Zcash.ZcashAddress!
 Nerdbank.Zcash.Transaction.SendItem.ToAddress.set -> void
 Nerdbank.Zcash.Transaction.Transaction(Nerdbank.Zcash.Transaction! original) -> void
-Nerdbank.Zcash.Transaction.Transaction(Nerdbank.Zcash.TxId transactionId, uint? minedHeight, bool expiredUnmined, System.DateTimeOffset? when, decimal netChange, decimal fee, System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.SendItem> outgoing, System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.RecvItem> incoming) -> void
+Nerdbank.Zcash.Transaction.Transaction(Nerdbank.Zcash.TxId transactionId, uint? minedHeight, bool expiredUnmined, System.DateTimeOffset? when, decimal netChange, decimal? fee, System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.SendItem> outgoing, System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.RecvItem> incoming) -> void
 Nerdbank.Zcash.Transaction.TransactionId.get -> Nerdbank.Zcash.TxId
 Nerdbank.Zcash.Transaction.When.get -> System.DateTimeOffset?
 Nerdbank.Zcash.Transparent.PrivateKey

--- a/src/Nerdbank.Zcash/RustBindings/LightWallet.cs
+++ b/src/Nerdbank.Zcash/RustBindings/LightWallet.cs
@@ -1661,7 +1661,7 @@ internal record Transaction(
 	uint? @minedHeight,
 	bool @expiredUnmined,
 	long @accountBalanceDelta,
-	ulong @fee,
+	ulong? @fee,
 	List<TransactionSendDetail> @outgoing,
 	List<TransparentNote> @incomingTransparent,
 	List<ShieldedNote> @incomingShielded
@@ -1680,7 +1680,7 @@ class FfiConverterTypeTransaction : FfiConverterRustBuffer<Transaction>
 			@minedHeight: FfiConverterOptionalUInt32.INSTANCE.Read(stream),
 			@expiredUnmined: FfiConverterBoolean.INSTANCE.Read(stream),
 			@accountBalanceDelta: FfiConverterInt64.INSTANCE.Read(stream),
-			@fee: FfiConverterUInt64.INSTANCE.Read(stream),
+			@fee: FfiConverterOptionalUInt64.INSTANCE.Read(stream),
 			@outgoing: FfiConverterSequenceTypeTransactionSendDetail.INSTANCE.Read(stream),
 			@incomingTransparent: FfiConverterSequenceTypeTransparentNote.INSTANCE.Read(stream),
 			@incomingShielded: FfiConverterSequenceTypeShieldedNote.INSTANCE.Read(stream)
@@ -1695,7 +1695,7 @@ class FfiConverterTypeTransaction : FfiConverterRustBuffer<Transaction>
 			+ FfiConverterOptionalUInt32.INSTANCE.AllocationSize(value.@minedHeight)
 			+ FfiConverterBoolean.INSTANCE.AllocationSize(value.@expiredUnmined)
 			+ FfiConverterInt64.INSTANCE.AllocationSize(value.@accountBalanceDelta)
-			+ FfiConverterUInt64.INSTANCE.AllocationSize(value.@fee)
+			+ FfiConverterOptionalUInt64.INSTANCE.AllocationSize(value.@fee)
 			+ FfiConverterSequenceTypeTransactionSendDetail.INSTANCE.AllocationSize(value.@outgoing)
 			+ FfiConverterSequenceTypeTransparentNote.INSTANCE.AllocationSize(
 				value.@incomingTransparent
@@ -1711,7 +1711,7 @@ class FfiConverterTypeTransaction : FfiConverterRustBuffer<Transaction>
 		FfiConverterOptionalUInt32.INSTANCE.Write(value.@minedHeight, stream);
 		FfiConverterBoolean.INSTANCE.Write(value.@expiredUnmined, stream);
 		FfiConverterInt64.INSTANCE.Write(value.@accountBalanceDelta, stream);
-		FfiConverterUInt64.INSTANCE.Write(value.@fee, stream);
+		FfiConverterOptionalUInt64.INSTANCE.Write(value.@fee, stream);
 		FfiConverterSequenceTypeTransactionSendDetail.INSTANCE.Write(value.@outgoing, stream);
 		FfiConverterSequenceTypeTransparentNote.INSTANCE.Write(value.@incomingTransparent, stream);
 		FfiConverterSequenceTypeShieldedNote.INSTANCE.Write(value.@incomingShielded, stream);
@@ -2389,6 +2389,45 @@ class FfiConverterOptionalUInt32 : FfiConverterRustBuffer<uint?>
 		{
 			stream.WriteByte(1);
 			FfiConverterUInt32.INSTANCE.Write((uint)value, stream);
+		}
+	}
+}
+
+class FfiConverterOptionalUInt64 : FfiConverterRustBuffer<ulong?>
+{
+	public static FfiConverterOptionalUInt64 INSTANCE = new FfiConverterOptionalUInt64();
+
+	public override ulong? Read(BigEndianStream stream)
+	{
+		if (stream.ReadByte() == 0)
+		{
+			return null;
+		}
+		return FfiConverterUInt64.INSTANCE.Read(stream);
+	}
+
+	public override int AllocationSize(ulong? value)
+	{
+		if (value == null)
+		{
+			return 1;
+		}
+		else
+		{
+			return 1 + FfiConverterUInt64.INSTANCE.AllocationSize((ulong)value);
+		}
+	}
+
+	public override void Write(ulong? value, BigEndianStream stream)
+	{
+		if (value == null)
+		{
+			stream.WriteByte(0);
+		}
+		else
+		{
+			stream.WriteByte(1);
+			FfiConverterUInt64.INSTANCE.Write((ulong)value, stream);
 		}
 	}
 }

--- a/src/Nerdbank.Zcash/Transaction.cs
+++ b/src/Nerdbank.Zcash/Transaction.cs
@@ -67,8 +67,11 @@ public partial record Transaction
 	public decimal NetChange { get; }
 
 	/// <summary>
-	/// Gets the transaction fee.
+	/// Gets the transaction fee, as a <em>positive</em> value.
 	/// </summary>
+	/// <remarks>
+	/// This fee is only relevant to the account's balance when <see cref="IsIncoming"/> is <see langword="false" />.
+	/// </remarks>
 	public decimal Fee { get; }
 
 	/// <summary>
@@ -82,13 +85,7 @@ public partial record Transaction
 	public ImmutableArray<RecvItem> Incoming { get; }
 
 	/// <summary>
-	/// Gets a value indicating whether this transaction sends funds from this account.
+	/// Gets a value indicating whether this transaction did not originate from this account.
 	/// </summary>
-	/// <remarks>
-	/// Note this only indicates that funds were sent from this account,
-	/// not that they were sent to <em>another</em> account.
-	/// They may in fact have been sent to the same account.
-	/// But this value is useful to determine whether the <see cref="Fee"/> came out of this account.
-	/// </remarks>
-	public bool IsOutgoing => this.Outgoing.Length > 0;
+	public bool IsIncoming => this.Outgoing.IsEmpty;
 }

--- a/src/Nerdbank.Zcash/Transaction.cs
+++ b/src/Nerdbank.Zcash/Transaction.cs
@@ -27,7 +27,7 @@ public partial record Transaction
 		bool expiredUnmined,
 		DateTimeOffset? when,
 		decimal netChange,
-		decimal fee,
+		decimal? fee,
 		ImmutableArray<SendItem> outgoing,
 		ImmutableArray<RecvItem> incoming)
 	{
@@ -72,7 +72,7 @@ public partial record Transaction
 	/// <remarks>
 	/// This fee is only relevant to the account's balance when <see cref="IsIncoming"/> is <see langword="false" />.
 	/// </remarks>
-	public decimal Fee { get; }
+	public decimal? Fee { get; }
 
 	/// <summary>
 	/// Gets the individual sent notes in this transaction.

--- a/src/nerdbank-zcash-rust/src/ffi.udl
+++ b/src/nerdbank-zcash-rust/src/ffi.udl
@@ -26,7 +26,7 @@ dictionary Transaction {
 	u32? mined_height;
 	boolean expired_unmined;
 	i64 account_balance_delta;
-	u64 fee;
+	u64? fee;
 	sequence<TransactionSendDetail> outgoing;
 	sequence<TransparentNote> incoming_transparent;
 	sequence<ShieldedNote> incoming_shielded;

--- a/src/nerdbank-zcash-rust/src/interop.rs
+++ b/src/nerdbank-zcash-rust/src/interop.rs
@@ -98,7 +98,7 @@ pub struct Transaction {
     pub mined_height: Option<u32>,
     pub expired_unmined: bool,
     pub account_balance_delta: i64,
-    pub fee: u64,
+    pub fee: Option<u64>,
     pub outgoing: Vec<TransactionSendDetail>,
     pub incoming_transparent: Vec<TransparentNote>,
     pub incoming_shielded: Vec<ShieldedNote>,

--- a/src/nerdbank-zcash-rust/src/sync.rs
+++ b/src/nerdbank-zcash-rust/src/sync.rs
@@ -736,7 +736,7 @@ pub fn get_transactions(
                     ),
                     None => None,
                 },
-                fee: row.get::<_, Option<u64>>("fee_paid")?.unwrap_or(0),
+                fee: row.get::<_, Option<u64>>("fee_paid")?,
                 account_balance_delta: row.get("account_balance_delta")?,
                 incoming_transparent: Vec::new(),
                 incoming_shielded: Vec::new(),


### PR DESCRIPTION
The only transactions that appear to be left with a null fee are the unshielded incoming (transparent->transparent), which is a lower priority since wallets don't typically need to display that to the user.

Closes #248