### PR TITLE
Allow for shorter F4Jumble inputs

### DIFF
--- a/src/Nerdbank.Zcash/UnifiedEncoding.cs
+++ b/src/Nerdbank.Zcash/UnifiedEncoding.cs
@@ -19,7 +19,7 @@ internal static class UnifiedEncoding
 	/// <summary>
 	/// The shortest allowed length of the input to the <see cref="F4Jumble"/> function.
 	/// </summary>
-	internal const int MinF4JumbleInputLength = 48;
+	internal const int MinF4JumbleInputLength = 40;
 
 	/// <summary>
 	/// The longest allowed length of the input to the <see cref="F4Jumble"/> function.

--- a/test/Nerdbank.Zcash.Tests/UnifiedAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/UnifiedAddressTests.cs
@@ -244,11 +244,11 @@ public class UnifiedAddressTests : TestBase
 			_ => throw new ArgumentOutOfRangeException(nameof(network)),
 		};
 
-		// We have to include expiration date metadata to push the length of the encoded data
-		// to the required 48 bytes.
+		// We have to include expiration block metadata to push the length of the encoded data
+		// to the required 40 bytes.
 		UnifiedEncodingMetadata metadata = new()
 		{
-			ExpirationDate = DateTimeOffset.Now,
+			ExpirationHeight = 100,
 		};
 
 		ZcashAccount account = new(new Zip32HDWallet(Mnemonic, network));


### PR DESCRIPTION
This allows for any metadata length to be included with a transparent address in order to make it legally encodable as a UA.
This change is consistent with the ZIP-316 rev. 1 change as described in https://github.com/zcash/zips/pull/797.
