### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.10.3",
+      "version": "17.10.4",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
   // Needs to be explicitly configured: https://github.com/Microsoft/azure-pipelines-vscode#document-formatting
   "[azure-pipelines]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": false // enable this when the conform
+    "editor.formatOnSave": false // enable this when they conform
   },
   "dotnet.defaultSolution": "Nerdbank.Cryptocurrencies.sln",
   "rust-analyzer.linkedProjects": [


### PR DESCRIPTION
- fix typo
- Bump dotnet-coverage from 17.10.3 to 17.10.4 (#264)
