### PR TITLE
Fix transparent transaction download, and improve cancellation response

### DIFF
--- a/src/nerdbank-zcash-rust/src/error.rs
+++ b/src/nerdbank-zcash-rust/src/error.rs
@@ -96,6 +96,8 @@ pub enum Error {
     KeyNotRecognized,
 
     Join(JoinError),
+
+    Canceled,
 }
 
 impl std::fmt::Display for Error {
@@ -138,6 +140,7 @@ impl std::fmt::Display for Error {
             Error::NoSpendingKey(e) => write!(f, "No spending key: {}", e),
             Error::KeyNotRecognized => f.write_str("No account found with the given key."),
             Error::Join(e) => e.fmt(f),
+            Error::Canceled => f.write_str("Canceled"),
         }
     }
 }

--- a/src/nerdbank-zcash-rust/src/interop.rs
+++ b/src/nerdbank-zcash-rust/src/interop.rs
@@ -188,6 +188,7 @@ impl From<Error> for LightWalletError {
             Error::TonicStatus(status) if status.code() == tonic::Code::Cancelled => {
                 LightWalletError::Canceled
             }
+            Error::Canceled => LightWalletError::Canceled,
             Error::InvalidArgument(msg) => LightWalletError::InvalidArgument { message: msg },
             Error::Internal(msg) => LightWalletError::Other { message: msg },
             Error::InsufficientFunds {

--- a/src/nerdbank-zcash-rust/src/sync.rs
+++ b/src/nerdbank-zcash-rust/src/sync.rs
@@ -460,9 +460,9 @@ fn calculate_transaction_fee(transaction: Transaction, conn: &Connection) -> Res
         .unwrap())
 }
 
-/// Initializes the fee column for every transaction that is missing it.
+/// Initializes the fee column for every transaction that is missing it (and that have blocks that have been downloaded).
 fn initialize_transaction_fees(db: &mut Db, conn: &Connection) -> Result<(), Error> {
-    conn.prepare("SELECT txid FROM transactions WHERE fee IS NULL")?
+    conn.prepare("SELECT txid FROM transactions WHERE fee IS NULL AND block IS NOT NULL")?
         .query_map([], |r| r.get::<_, [u8; 32]>(0).map(TxId::from_bytes))?
         .try_for_each(|txid| {
             let txid = txid?;


### PR DESCRIPTION
- Fix download of transparent transactions
- Fix initializing fees for transparent transactions before their (shielded) blocks are downloaded
- Dramatically improve response time to sync cancellation