### PR TITLE
Allow importing wallets with short seed phrases

### DIFF
--- a/src/Nerdbank.Cryptocurrencies/Strings.es.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.es.resx
@@ -150,9 +150,6 @@
   <data name="SecurityMismatch" xml:space="preserve">
     <value>Esta operación requiere que todas las entradas sean del mismo tipo de seguridad.</value>
   </data>
-  <data name="HistoricalPricesNotAvailable" xml:space="preserve">
-    <value>Los precios históricos no están disponibles en este intercambio.</value>
-  </data>
   <data name="TradingPairNotSupported" xml:space="preserve">
     <value>Esta bolsa no ofrece este par de trading.</value>
   </data>

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -950,6 +950,7 @@ static Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails.operator !=
 static Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails.operator ==(Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails? left, Nerdbank.Zcash.Zip321PaymentRequestUris.PaymentRequestDetails? right) -> bool
 static Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag.From(in Nerdbank.Bitcoin.Bip32HDWallet.ParentFingerprint value) -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag
 static Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag.From(System.ReadOnlySpan<byte> value) -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag
+static Nerdbank.Zcash.Zip32HDWallet.HasAtLeastRecommendedEntropy(Nerdbank.Bitcoin.Bip39Mnemonic! mnemonic) -> bool
 static Nerdbank.Zcash.Zip32HDWallet.Orchard.Create(Nerdbank.Bitcoin.Bip39Mnemonic! mnemonic, Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey!
 static Nerdbank.Zcash.Zip32HDWallet.Orchard.Create(System.ReadOnlySpan<byte> seed, Nerdbank.Zcash.ZcashNetwork network) -> Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey!
 static Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Zip32HDWallet.Orchard.ExtendedSpendingKey? key) -> bool

--- a/src/Nerdbank.Zcash/Strings.es.resx
+++ b/src/Nerdbank.Zcash/Strings.es.resx
@@ -180,9 +180,6 @@
   <data name="LengthRangeNotMet" xml:space="preserve">
     <value>Este valor debe tener una longitud de {minimum}-{maximum}.</value>
   </data>
-  <data name="NotEnoughEntropy" xml:space="preserve">
-    <value>La entropía es demasiado corta. Se requieren al menos {minimum} bytes.</value>
-  </data>
   <data name="ErrorFromNativeSide" xml:space="preserve">
     <value>Se produjo un error no asignado en la capa de interoperabilidad.</value>
   </data>

--- a/src/Nerdbank.Zcash/Strings.resx
+++ b/src/Nerdbank.Zcash/Strings.resx
@@ -183,9 +183,6 @@
   <data name="NetworkMismatch" xml:space="preserve">
     <value>This server is configured for use on the {expected} network, but the input parameter is on the {actual} network.</value>
   </data>
-  <data name="NotEnoughEntropy" xml:space="preserve">
-    <value>The entropy is too short. At least {minimum} bytes are required.</value>
-  </data>
   <data name="OnlyHardenedChildKeysSupported" xml:space="preserve">
     <value>Only hardened keys are supported.</value>
   </data>

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Orchard.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Orchard.cs
@@ -17,7 +17,7 @@ public partial class Zip32HDWallet
 		/// <inheritdoc cref="Create(ReadOnlySpan{byte}, ZcashNetwork)"/>
 		/// <param name="mnemonic">The mnemonic phrase from which to generate the master key.</param>
 		/// <param name="network"><inheritdoc cref="Create(ReadOnlySpan{byte}, ZcashNetwork)" path="/param[@name='network']"/></param>
-		public static ExtendedSpendingKey Create(Bip39Mnemonic mnemonic, ZcashNetwork network) => Create(ThrowIfEntropyTooShort(Requires.NotNull(mnemonic)).Seed, network);
+		public static ExtendedSpendingKey Create(Bip39Mnemonic mnemonic, ZcashNetwork network) => Create(Requires.NotNull(mnemonic).Seed, network);
 
 		/// <summary>
 		/// Creates a master key for the Orchard pool.

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.cs
@@ -17,7 +17,7 @@ public partial class Zip32HDWallet
 		/// <inheritdoc cref="Create(ReadOnlySpan{byte}, ZcashNetwork)"/>
 		/// <param name="mnemonic">The mnemonic phrase from which to generate the master key.</param>
 		/// <param name="network"><inheritdoc cref="Create(ReadOnlySpan{byte}, ZcashNetwork)" path="/param[@name='network']"/></param>
-		public static ExtendedSpendingKey Create(Bip39Mnemonic mnemonic, ZcashNetwork network) => Create(ThrowIfEntropyTooShort(Requires.NotNull(mnemonic)).Seed, network);
+		public static ExtendedSpendingKey Create(Bip39Mnemonic mnemonic, ZcashNetwork network) => Create(Requires.NotNull(mnemonic).Seed, network);
 
 		/// <summary>
 		/// Creates a master key for the Sapling pool.

--- a/src/Nerdbank.Zcash/Zip32HDWallet.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.cs
@@ -55,7 +55,7 @@ public partial class Zip32HDWallet : IEquatable<Zip32HDWallet>
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 	public Zip32HDWallet(Bip39Mnemonic mnemonic, ZcashNetwork network = ZcashNetwork.MainNet)
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
-		: this(ThrowIfEntropyTooShort(Requires.NotNull(mnemonic)).Seed, network)
+		: this(Requires.NotNull(mnemonic).Seed, network)
 	{
 		this.Mnemonic = mnemonic;
 	}
@@ -96,6 +96,13 @@ public partial class Zip32HDWallet : IEquatable<Zip32HDWallet>
 	/// Gets the coin type to use, considering the <see cref="Network"/> this wallet operates on.
 	/// </summary>
 	private uint CoinType => this.Network == ZcashNetwork.MainNet ? MainNetCoinType : TestNetCoinType;
+
+	/// <summary>
+	/// Checks whether a given mnemonic is long enough to meet Zcash security recommendations.
+	/// </summary>
+	/// <param name="mnemonic">The mnemonic to test.</param>
+	/// <returns><see langword="true" /> if the mnemonic is long enough; <see langword="false"/> otherwise.</returns>
+	public static bool HasAtLeastRecommendedEntropy(Bip39Mnemonic mnemonic) => Requires.NotNull(mnemonic).Entropy.Length * 8 >= MinimumEntropyLengthInBits;
 
 	/// <summary>
 	/// Creates a key derivation path that conforms to the <see href="https://zips.z.cash/zip-0032#specification-wallet-usage">ZIP-32</see> specification
@@ -232,15 +239,5 @@ public partial class Zip32HDWallet : IEquatable<Zip32HDWallet>
 		{
 			throw new ArgumentException(Strings.FormatLengthRangeNotMet(MasterSeedAllowedLength.Min, MasterSeedAllowedLength.Max), nameof(seed));
 		}
-	}
-
-	private static Bip39Mnemonic ThrowIfEntropyTooShort(Bip39Mnemonic mnemonic)
-	{
-		if (mnemonic.Entropy.Length * 8 < MinimumEntropyLengthInBits)
-		{
-			throw new ArgumentException(Strings.FormatNotEnoughEntropy(MinimumEntropyLengthInBits / 8), nameof(mnemonic));
-		}
-
-		return mnemonic;
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
+++ b/test/Nerdbank.Zcash.Tests/Zip32HDWalletTests.cs
@@ -92,24 +92,30 @@ public class Zip32HDWalletTests : TestBase
 	public void Zip32_Ctor_SeedPhraseLengthRequirements()
 	{
 		Bip39Mnemonic shortMnemonic = Bip39Mnemonic.Create(Zip32HDWallet.MinimumEntropyLengthInBits - 32);
-		ArgumentException ex = Assert.Throws<ArgumentException>(() => new Zip32HDWallet(shortMnemonic, ZcashNetwork.MainNet));
-		this.logger.WriteLine(ex.Message);
+		var x = new Zip32HDWallet(shortMnemonic, ZcashNetwork.MainNet);
+	}
+
+	[Fact]
+	public void HasAtLeastRecommendedEntropy()
+	{
+		Bip39Mnemonic goodMnemonic = Bip39Mnemonic.Create(Zip32HDWallet.MinimumEntropyLengthInBits);
+		Assert.True(Zip32HDWallet.HasAtLeastRecommendedEntropy(goodMnemonic));
+		Bip39Mnemonic shortMnemonic = Bip39Mnemonic.Create(Zip32HDWallet.MinimumEntropyLengthInBits - 32);
+		Assert.False(Zip32HDWallet.HasAtLeastRecommendedEntropy(shortMnemonic));
 	}
 
 	[Fact]
 	public void Orchard_Create_SeedPhraseLengthRequirements()
 	{
 		Bip39Mnemonic shortMnemonic = Bip39Mnemonic.Create(Zip32HDWallet.MinimumEntropyLengthInBits - 32);
-		ArgumentException ex = Assert.Throws<ArgumentException>(() => Zip32HDWallet.Orchard.Create(shortMnemonic, ZcashNetwork.MainNet));
-		this.logger.WriteLine(ex.Message);
+		Assert.NotNull(Zip32HDWallet.Orchard.Create(shortMnemonic, ZcashNetwork.MainNet));
 	}
 
 	[Fact]
 	public void Sapling_Create_SeedPhraseLengthRequirements()
 	{
 		Bip39Mnemonic shortMnemonic = Bip39Mnemonic.Create(Zip32HDWallet.MinimumEntropyLengthInBits - 32);
-		ArgumentException ex = Assert.Throws<ArgumentException>(() => Zip32HDWallet.Sapling.Create(shortMnemonic, ZcashNetwork.MainNet));
-		this.logger.WriteLine(ex.Message);
+		Assert.NotNull(Zip32HDWallet.Sapling.Create(shortMnemonic, ZcashNetwork.MainNet));
 	}
 
 	[Fact]


### PR DESCRIPTION
Some seed phrases (such as those generated by the Unstoppable wallet) are only 12 words long. We should not prevent users importing those seed phrases to recover their funds, even if they are not regulation length.