### PR TITLE
Optimized birthday height should be null when no transaction is found

### DIFF
--- a/src/Nerdbank.Zcash/LightWalletClient.cs
+++ b/src/Nerdbank.Zcash/LightWalletClient.cs
@@ -573,7 +573,7 @@ public partial class LightWalletClient : IDisposable
 	/// <param name="OriginalBirthdayHeight">The birthday height the account was created with.</param>
 	/// <param name="BirthdayHeight">The height of the first block that contains a transaction.</param>
 	/// <param name="RebirthHeight">The height of the block containing the oldest unspent note.</param>
-	public record struct BirthdayHeights(ulong OriginalBirthdayHeight, ulong BirthdayHeight, ulong? RebirthHeight)
+	public record struct BirthdayHeights(ulong OriginalBirthdayHeight, ulong? BirthdayHeight, ulong? RebirthHeight)
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="BirthdayHeights"/> struct.

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -61,11 +61,11 @@ Nerdbank.Zcash.LightWalletClient.AddAccountAsync(Nerdbank.Zcash.ZcashAccount! ac
 Nerdbank.Zcash.LightWalletClient.AddDiversifier(Nerdbank.Zcash.ZcashAccount! account, Nerdbank.Zcash.DiversifierIndex diversifierIndex) -> Nerdbank.Zcash.UnifiedAddress!
 Nerdbank.Zcash.LightWalletClient.BirthdayHeight.get -> uint?
 Nerdbank.Zcash.LightWalletClient.BirthdayHeights
-Nerdbank.Zcash.LightWalletClient.BirthdayHeights.BirthdayHeight.get -> ulong
+Nerdbank.Zcash.LightWalletClient.BirthdayHeights.BirthdayHeight.get -> ulong?
 Nerdbank.Zcash.LightWalletClient.BirthdayHeights.BirthdayHeight.set -> void
 Nerdbank.Zcash.LightWalletClient.BirthdayHeights.BirthdayHeights() -> void
-Nerdbank.Zcash.LightWalletClient.BirthdayHeights.BirthdayHeights(ulong OriginalBirthdayHeight, ulong BirthdayHeight, ulong? RebirthHeight) -> void
-Nerdbank.Zcash.LightWalletClient.BirthdayHeights.Deconstruct(out ulong OriginalBirthdayHeight, out ulong BirthdayHeight, out ulong? RebirthHeight) -> void
+Nerdbank.Zcash.LightWalletClient.BirthdayHeights.BirthdayHeights(ulong OriginalBirthdayHeight, ulong? BirthdayHeight, ulong? RebirthHeight) -> void
+Nerdbank.Zcash.LightWalletClient.BirthdayHeights.Deconstruct(out ulong OriginalBirthdayHeight, out ulong? BirthdayHeight, out ulong? RebirthHeight) -> void
 Nerdbank.Zcash.LightWalletClient.BirthdayHeights.Equals(Nerdbank.Zcash.LightWalletClient.BirthdayHeights other) -> bool
 Nerdbank.Zcash.LightWalletClient.BirthdayHeights.OriginalBirthdayHeight.get -> ulong
 Nerdbank.Zcash.LightWalletClient.BirthdayHeights.OriginalBirthdayHeight.set -> void

--- a/src/Nerdbank.Zcash/RustBindings/LightWallet.cs
+++ b/src/Nerdbank.Zcash/RustBindings/LightWallet.cs
@@ -1209,7 +1209,7 @@ class FfiConverterTypeAccountInfo: FfiConverterRustBuffer<AccountInfo> {
 
 internal record BirthdayHeights (
     uint @originalBirthdayHeight, 
-    uint @birthdayHeight, 
+    uint? @birthdayHeight, 
     uint? @rebirthHeight
 ) {
 }
@@ -1220,7 +1220,7 @@ class FfiConverterTypeBirthdayHeights: FfiConverterRustBuffer<BirthdayHeights> {
     public override BirthdayHeights Read(BigEndianStream stream) {
         return new BirthdayHeights(
             @originalBirthdayHeight: FfiConverterUInt32.INSTANCE.Read(stream),
-            @birthdayHeight: FfiConverterUInt32.INSTANCE.Read(stream),
+            @birthdayHeight: FfiConverterOptionalUInt32.INSTANCE.Read(stream),
             @rebirthHeight: FfiConverterOptionalUInt32.INSTANCE.Read(stream)
         );
     }
@@ -1228,13 +1228,13 @@ class FfiConverterTypeBirthdayHeights: FfiConverterRustBuffer<BirthdayHeights> {
     public override int AllocationSize(BirthdayHeights value) {
         return
             FfiConverterUInt32.INSTANCE.AllocationSize(value.@originalBirthdayHeight) +
-            FfiConverterUInt32.INSTANCE.AllocationSize(value.@birthdayHeight) +
+            FfiConverterOptionalUInt32.INSTANCE.AllocationSize(value.@birthdayHeight) +
             FfiConverterOptionalUInt32.INSTANCE.AllocationSize(value.@rebirthHeight);
     }
 
     public override void Write(BirthdayHeights value, BigEndianStream stream) {
             FfiConverterUInt32.INSTANCE.Write(value.@originalBirthdayHeight, stream);
-            FfiConverterUInt32.INSTANCE.Write(value.@birthdayHeight, stream);
+            FfiConverterOptionalUInt32.INSTANCE.Write(value.@birthdayHeight, stream);
             FfiConverterOptionalUInt32.INSTANCE.Write(value.@rebirthHeight, stream);
     }
 }

--- a/src/nerdbank-zcash-rust/src/ffi.udl
+++ b/src/nerdbank-zcash-rust/src/ffi.udl
@@ -62,7 +62,7 @@ dictionary UserBalances {
 
 dictionary BirthdayHeights {
 	u32 original_birthday_height;
-	u32 birthday_height;
+	u32? birthday_height;
 	u32? rebirth_height;
 };
 


### PR DESCRIPTION
Previously, the optimized birthday height was set to the sapling activation height when no transaction was found. It now is set to null in that case.