### PR TITLE
Implement ZIP-320 TEX addresses

### DIFF
--- a/src/Nerdbank.Cryptocurrencies/Bech32.cs
+++ b/src/Nerdbank.Cryptocurrencies/Bech32.cs
@@ -54,7 +54,7 @@ public sealed class Bech32
 	public static int GetEncodedLength(int tagLength, int dataLength) => tagLength + 1 + (int)Math.Ceiling((double)dataLength * 8 / 5) + 6;
 
 	/// <summary>
-	/// Gets the maximum number of bytes that can be decoded from a given number of characters.
+	/// Gets the maximum number of bytes that can be decoded from a given sequence of characters.
 	/// </summary>
 	/// <param name="encoded">The Bech32 characters to decode.</param>
 	/// <returns>

--- a/src/Nerdbank.Zcash.Cli/AccountsCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/AccountsCommand.cs
@@ -16,6 +16,7 @@ internal class AccountsCommand : WalletUserCommandBase
 		Command command = new("accounts", Strings.AccountsCommandDescription)
 		{
 			WalletPathArgument,
+			TestNetOption,
 		};
 
 		command.SetHandler(async ctxt =>
@@ -24,6 +25,7 @@ internal class AccountsCommand : WalletUserCommandBase
 			{
 				Console = ctxt.Console,
 				WalletPath = ctxt.ParseResult.GetValueForArgument(WalletPathArgument),
+				TestNet = ctxt.ParseResult.GetValueForOption(TestNetOption),
 			}.ExecuteAsync(ctxt.GetCancellationToken());
 		});
 

--- a/src/Nerdbank.Zcash.Cli/ImportAccountCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/ImportAccountCommand.cs
@@ -30,7 +30,7 @@ internal class ImportAccountCommand
 		Option<ulong> birthdayHeightOption = new("--birthday-height", Strings.BirthdayHeightOptionDescription);
 		Option<Uri> lightServerUriOption = new("--lightserverUrl", Strings.LightServerUrlOptionDescription);
 
-		Command command = new("ImportAccount", Strings.ImportAccountCommandDescription)
+		Command command = new("import", Strings.ImportAccountCommandDescription)
 		{
 			keyArgument,
 			walletPathOption,

--- a/src/Nerdbank.Zcash.Cli/NewAccountCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/NewAccountCommand.cs
@@ -66,7 +66,7 @@ internal class NewAccountCommand
 
 		Option<ulong> birthdayHeightOption = new("--birthday-height", Strings.BirthdayHeightOptionDescription);
 
-		Command command = new("NewAccount", Strings.NewAccountCommandDescription)
+		Command command = new("new", Strings.NewAccountCommandDescription)
 		{
 			seedPhraseWordLengthOption,
 			seedPhraseOption,

--- a/src/Nerdbank.Zcash.Cli/NewAccountCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/NewAccountCommand.cs
@@ -53,11 +53,7 @@ internal class NewAccountCommand
 
 		Option<string> seedPhrasePasswordOption = new("--password", Strings.PasswordOptionDescription);
 
-		Option<bool> testNetOption = new("--testnet", Strings.TestNetOptionDescription);
-
 		Option<uint> accountIndexOption = new("--index", () => 0, Strings.AccountIndexOptionDescription);
-
-		Option<Uri> lightServerUriOption = new("--lightserverUrl", Strings.LightServerUrlOptionDescription);
 
 		Option<bool> offlineModeOption = new("--offline", Strings.OfflineOptionDescription);
 
@@ -71,9 +67,9 @@ internal class NewAccountCommand
 			seedPhraseWordLengthOption,
 			seedPhraseOption,
 			seedPhrasePasswordOption,
-			testNetOption,
+			WalletUserCommandBase.TestNetOption,
 			accountIndexOption,
-			lightServerUriOption,
+			WalletUserCommandBase.LightServerUriOption,
 			offlineModeOption,
 			walletPathOption,
 			birthdayHeightOption,
@@ -96,9 +92,9 @@ internal class NewAccountCommand
 				SeedPhrase = ctxt.ParseResult.GetValueForOption(seedPhraseOption),
 				PromptForSeedPhrase = ctxt.ParseResult.FindResultFor(seedPhraseOption) is { Token: not null, Tokens: { Count: 0 } },
 				Password = ctxt.ParseResult.GetValueForOption(seedPhrasePasswordOption),
-				TestNet = ctxt.ParseResult.GetValueForOption(testNetOption),
+				TestNet = ctxt.ParseResult.GetValueForOption(WalletUserCommandBase.TestNetOption),
 				AccountIndex = ctxt.ParseResult.GetValueForOption(accountIndexOption),
-				LightWalletServerUrl = ctxt.ParseResult.GetValueForOption(lightServerUriOption),
+				LightWalletServerUrl = ctxt.ParseResult.GetValueForOption(WalletUserCommandBase.LightServerUriOption),
 				OfflineMode = ctxt.ParseResult.GetValueForOption(offlineModeOption),
 				WalletPath = ctxt.ParseResult.GetValueForOption(walletPathOption),
 				BirthdayHeight = ctxt.ParseResult.GetValueForOption(birthdayHeightOption),

--- a/src/Nerdbank.Zcash.Cli/Program.cs
+++ b/src/Nerdbank.Zcash.Cli/Program.cs
@@ -13,6 +13,7 @@ Command rootCommand = new(Assembly.GetExecutingAssembly().GetName().Name!, Strin
 	NewAccountCommand.BuildCommand(),
 	ImportAccountCommand.BuildCommand(),
 	UACommand.BuildCommand(),
+	TexCommand.BuildCommand(),
 	SyncCommand.BuildCommand(),
 	BalanceCommand.BuildCommand(),
 	HistoryCommand.BuildCommand(),

--- a/src/Nerdbank.Zcash.Cli/RequestPaymentCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/RequestPaymentCommand.cs
@@ -34,7 +34,7 @@ internal class RequestPaymentCommand
 		Option<string[]> messagesOption = new("--message", Strings.RequestPaymentMessageOptionDescription) { Arity = ArgumentArity.OneOrMore };
 		Option<string> saveQRCodeOption = new Option<string>("--output", Strings.RequestPaymentSaveQRCodeOption).LegalFilePathsOnly();
 
-		Command command = new("RequestPayment", Strings.RequestPaymentCommandDescription)
+		Command command = new("invoice", Strings.RequestPaymentCommandDescription)
 		{
 			payeesArgument,
 			amountsOption,

--- a/src/Nerdbank.Zcash.Cli/SendCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/SendCommand.cs
@@ -61,7 +61,7 @@ internal class SendCommand : SyncFirstCommandBase
 		}
 
 		Transaction.LineItem item = new(this.Recipient, this.Amount, Zcash.Memo.FromMessage(this.Memo));
-		ReadOnlyMemory<TxId> txid = await client.SendAsync(
+		ReadOnlyMemory<TxId> txids = await client.SendAsync(
 			this.SelectedAccount!,
 			[item],
 			new Progress<LightWalletClient.SendProgress>(p =>
@@ -73,7 +73,10 @@ internal class SendCommand : SyncFirstCommandBase
 			}),
 			cancellationToken);
 
-		this.Console.WriteLine($"Transmitted transaction ID: {txid}");
+		for (int i = 0; i < txids.Length; i++)
+		{
+			this.Console.WriteLine($"Transmitted transaction ID: {txids.Span[i]}");
+		}
 
 		return 0;
 	}

--- a/src/Nerdbank.Zcash.Cli/Strings.es.resx
+++ b/src/Nerdbank.Zcash.Cli/Strings.es.resx
@@ -252,6 +252,15 @@
   <data name="TestNetOptionDescription" xml:space="preserve">
     <value>Indica que la cuenta se utilizará en una red de prueba en lugar de en una red principal.</value>
   </data>
+  <data name="TexCommandDescription" xml:space="preserve">
+    <value>Convierte una dirección transparente en una dirección TEX.</value>
+  </data>
+  <data name="TexTransparentAddressArgumentDescription" xml:space="preserve">
+    <value>La dirección transparente para convertir.</value>
+  </data>
+  <data name="TransparentP2PKHAddressRequired" xml:space="preserve">
+    <value>Se requiere una dirección transparente P2PKH.</value>
+  </data>
   <data name="UACommandDescription" xml:space="preserve">
     <value>Codifica o decodifica direcciones UA.</value>
   </data>

--- a/src/Nerdbank.Zcash.Cli/Strings.fr.resx
+++ b/src/Nerdbank.Zcash.Cli/Strings.fr.resx
@@ -252,6 +252,15 @@
   <data name="TestNetOptionDescription" xml:space="preserve">
     <value>Indique que le compte sera utilisé sur un testnet au lieu de mainnet.</value>
   </data>
+  <data name="TexCommandDescription" xml:space="preserve">
+    <value>Convertit une adresse transparente en une adresse Tex.</value>
+  </data>
+  <data name="TexTransparentAddressArgumentDescription" xml:space="preserve">
+    <value>L'adresse transparente à convertir.</value>
+  </data>
+  <data name="TransparentP2PKHAddressRequired" xml:space="preserve">
+    <value>Une adresse transparente P2PKH est requise.</value>
+  </data>
   <data name="UACommandDescription" xml:space="preserve">
     <value>Encode ou décode les adresses UA.</value>
   </data>

--- a/src/Nerdbank.Zcash.Cli/Strings.ko.resx
+++ b/src/Nerdbank.Zcash.Cli/Strings.ko.resx
@@ -252,6 +252,15 @@
   <data name="TestNetOptionDescription" xml:space="preserve">
     <value>메인넷 대신 테스트넷에서 계정을 사용할 것을 나타냅니다.</value>
   </data>
+  <data name="TexCommandDescription" xml:space="preserve">
+    <value>투명한 주소를 TEX 주소로 변환합니다.</value>
+  </data>
+  <data name="TexTransparentAddressArgumentDescription" xml:space="preserve">
+    <value>변환 할 투명한 주소.</value>
+  </data>
+  <data name="TransparentP2PKHAddressRequired" xml:space="preserve">
+    <value>P2PKH 투명 주소가 필요합니다.</value>
+  </data>
   <data name="UACommandDescription" xml:space="preserve">
     <value>UA 주소를 인코딩하거나 디코딩합니다.</value>
   </data>

--- a/src/Nerdbank.Zcash.Cli/Strings.pt.resx
+++ b/src/Nerdbank.Zcash.Cli/Strings.pt.resx
@@ -252,6 +252,15 @@
   <data name="TestNetOptionDescription" xml:space="preserve">
     <value>Indica que a conta será usada em uma testnet em vez de mainnet.</value>
   </data>
+  <data name="TexCommandDescription" xml:space="preserve">
+    <value>Converte um endereço transparente em um endereço TEX.</value>
+  </data>
+  <data name="TexTransparentAddressArgumentDescription" xml:space="preserve">
+    <value>O endereço transparente para converter.</value>
+  </data>
+  <data name="TransparentP2PKHAddressRequired" xml:space="preserve">
+    <value>É necessário um endereço transparente P2PKH.</value>
+  </data>
   <data name="UACommandDescription" xml:space="preserve">
     <value>Codifica ou decodifica endereços UA.</value>
   </data>

--- a/src/Nerdbank.Zcash.Cli/Strings.resx
+++ b/src/Nerdbank.Zcash.Cli/Strings.resx
@@ -252,6 +252,15 @@
   <data name="TestNetOptionDescription" xml:space="preserve">
     <value>Indicates the account will be used on a testnet instead of mainnet.</value>
   </data>
+  <data name="TexCommandDescription" xml:space="preserve">
+    <value>Converts a transparent address into a TEX address.</value>
+  </data>
+  <data name="TexTransparentAddressArgumentDescription" xml:space="preserve">
+    <value>The transparent address to convert.</value>
+  </data>
+  <data name="TransparentP2PKHAddressRequired" xml:space="preserve">
+    <value>A P2PKH transparent address is required.</value>
+  </data>
   <data name="UACommandDescription" xml:space="preserve">
     <value>Encodes or decodes UA addresses.</value>
   </data>

--- a/src/Nerdbank.Zcash.Cli/Strings.ru.resx
+++ b/src/Nerdbank.Zcash.Cli/Strings.ru.resx
@@ -252,6 +252,15 @@
   <data name="TestNetOptionDescription" xml:space="preserve">
     <value>Указывает, что учетная запись будет использоваться в Testnet вместо Mainnet.</value>
   </data>
+  <data name="TexCommandDescription" xml:space="preserve">
+    <value>Преобразует прозрачный адрес в адрес TEX.</value>
+  </data>
+  <data name="TexTransparentAddressArgumentDescription" xml:space="preserve">
+    <value>Прозрачный адрес для конвертации.</value>
+  </data>
+  <data name="TransparentP2PKHAddressRequired" xml:space="preserve">
+    <value>Требуется прозрачный адрес P2PKH.</value>
+  </data>
   <data name="UACommandDescription" xml:space="preserve">
     <value>Кодирует или декодирует адреса UA.</value>
   </data>

--- a/src/Nerdbank.Zcash.Cli/Strings.zh-Hans.resx
+++ b/src/Nerdbank.Zcash.Cli/Strings.zh-Hans.resx
@@ -252,6 +252,15 @@
   <data name="TestNetOptionDescription" xml:space="preserve">
     <value>指示该账户将在测试网而不是主网上使用。</value>
   </data>
+  <data name="TexCommandDescription" xml:space="preserve">
+    <value>将透明的地址转换为TEX地址。</value>
+  </data>
+  <data name="TexTransparentAddressArgumentDescription" xml:space="preserve">
+    <value>转换的透明地址。</value>
+  </data>
+  <data name="TransparentP2PKHAddressRequired" xml:space="preserve">
+    <value>需要P2PKH透明地址。</value>
+  </data>
   <data name="UACommandDescription" xml:space="preserve">
     <value>编码或解码 UA 地址。</value>
   </data>

--- a/src/Nerdbank.Zcash.Cli/TexCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/TexCommand.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine;
+using System.CommandLine.IO;
+
+namespace Nerdbank.Zcash.Cli;
+
+internal class TexCommand
+{
+	internal required IConsole Console { get; init; }
+
+	internal required string TransparentAddress { get; init; }
+
+	internal static Command BuildCommand()
+	{
+		Argument<string> transparentAddressArgument = new("transparentAddress", Strings.TexTransparentAddressArgumentDescription) { Arity = ArgumentArity.ExactlyOne };
+		Command command = new Command("tex", Strings.TexCommandDescription)
+		{
+			transparentAddressArgument,
+		};
+
+		command.SetHandler(ctxt =>
+		{
+			ctxt.ExitCode = new TexCommand
+			{
+				Console = ctxt.Console,
+				TransparentAddress = ctxt.ParseResult.GetValueForArgument(transparentAddressArgument),
+			}.Execute(ctxt.GetCancellationToken());
+		});
+		return command;
+	}
+
+	private int Execute(CancellationToken cancellationToken)
+	{
+		if (!ZcashAddress.TryDecode(this.TransparentAddress, out _, out string? errorMessage, out ZcashAddress? result))
+		{
+			this.Console.Error.WriteLine(errorMessage);
+			return 1;
+		}
+
+		if (result is not TransparentP2PKHAddress tAddr)
+		{
+			this.Console.Error.WriteLine(Strings.TransparentP2PKHAddressRequired);
+			return 2;
+		}
+
+		TexAddress tex = new(tAddr);
+		this.Console.WriteLine(tex);
+		return 0;
+	}
+}

--- a/src/Nerdbank.Zcash.Cli/WalletUserCommandBase.cs
+++ b/src/Nerdbank.Zcash.Cli/WalletUserCommandBase.cs
@@ -22,6 +22,10 @@ internal abstract class WalletUserCommandBase
 		this.LightWalletServerUrl = copyFrom.LightWalletServerUrl;
 	}
 
+	internal static Option<bool> TestNetOption { get; } = new("--testnet", Strings.TestNetOptionDescription);
+
+	internal static Option<Uri> LightServerUriOption { get; } = new("--lightserverUrl", Strings.LightServerUrlOptionDescription);
+
 	internal required IConsole Console { get; init; }
 
 	internal required string WalletPath { get; init; }
@@ -39,10 +43,6 @@ internal abstract class WalletUserCommandBase
 	internal uint SpendingKeyAccountIndex { get; init; }
 
 	protected static Argument<string> WalletPathArgument { get; } = new Argument<string>("wallet path", Strings.WalletPathArgumentDescription).LegalFilePathsOnly();
-
-	protected static Option<bool> TestNetOption { get; } = new("--testnet", Strings.TestNetOptionDescription);
-
-	protected static Option<Uri> LightServerUriOption { get; } = new("--lightserverUrl", Strings.LightServerUrlOptionDescription);
 
 	protected static Option<ZcashAddress> OptionalSelectedAccountOption { get; } = new("--account", parseArgument: arg => ZcashAddress.Decode(arg.Tokens[0].Value), description: Strings.SelectedAccountArgumentDescription);
 

--- a/src/Nerdbank.Zcash/IPoolReceiver.cs
+++ b/src/Nerdbank.Zcash/IPoolReceiver.cs
@@ -9,11 +9,6 @@ namespace Nerdbank.Zcash;
 public interface IPoolReceiver
 {
 	/// <summary>
-	/// Gets the type code that identifies the type of receiver in a Unified Address.
-	/// </summary>
-	static abstract byte UnifiedReceiverTypeCode { get; }
-
-	/// <summary>
 	/// Gets the pool that this receiver can send funds into.
 	/// </summary>
 	Pool Pool { get; }

--- a/src/Nerdbank.Zcash/IUnifiedPoolReceiver.cs
+++ b/src/Nerdbank.Zcash/IUnifiedPoolReceiver.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.Zcash;
+
+/// <summary>
+/// An interface implemented by receivers that are embedded in Zcash addresses
+/// that are allowed in unified addresses.
+/// </summary>
+public interface IUnifiedPoolReceiver : IPoolReceiver
+{
+	/// <summary>
+	/// Gets the type code that identifies the type of receiver in a Unified Address.
+	/// </summary>
+	static abstract byte UnifiedReceiverTypeCode { get; }
+}

--- a/src/Nerdbank.Zcash/LightWalletClient.cs
+++ b/src/Nerdbank.Zcash/LightWalletClient.cs
@@ -288,9 +288,12 @@ public partial class LightWalletClient : IDisposable
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The IDs of the transaction(s) that were broadcast to complete the transfer.</returns>
 	/// <remarks>
+	/// <para>
 	/// A single logical transfer may be divided into multiple transactions, or steps, when the receiver's address
-	/// does not allow shielded funds to be sent directly to it.
-	/// In such cases, the shielded funds are sent to a transparent address, and then from there to the receiver.
+	/// does not allow shielded funds to be sent directly to it (e.g. <see cref="TexAddress"/>).
+	/// In such cases, the shielded funds are first sent to a transparent address controlled by <em>this</em> account,
+	/// and then from there to the receiver.
+	/// </para>
 	/// </remarks>
 	/// <exception cref="LightWalletException">Thrown when the spend is invalid (e.g. insufficient funds).</exception>
 	public async Task<ReadOnlyMemory<TxId>> SendAsync(ZcashAccount account, IReadOnlyCollection<LineItem> payments, IProgress<SendProgress>? progress, CancellationToken cancellationToken)

--- a/src/Nerdbank.Zcash/OrchardReceiver.cs
+++ b/src/Nerdbank.Zcash/OrchardReceiver.cs
@@ -9,7 +9,7 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Orchard"/> pool.
 /// </summary>
-public unsafe struct OrchardReceiver : IPoolReceiver
+public unsafe struct OrchardReceiver : IUnifiedPoolReceiver
 {
 	private const int DLength = 88 / 8;
 	private const int PkdLength = 256 / 8;
@@ -53,7 +53,7 @@ public unsafe struct OrchardReceiver : IPoolReceiver
 		receiver.CopyTo(this.SpanWritable);
 	}
 
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
+	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
 	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.Orchard;
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -421,8 +421,19 @@ Nerdbank.Zcash.SproutReceiver.Span.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SproutReceiver.SproutReceiver() -> void
 Nerdbank.Zcash.SproutReceiver.SproutReceiver(System.ReadOnlySpan<byte> apk, System.ReadOnlySpan<byte> pkEnc) -> void
 Nerdbank.Zcash.TexAddress
-Nerdbank.Zcash.TexAddress.TexAddress(in Nerdbank.Zcash.TransparentP2PKHReceiver receiver, Nerdbank.Zcash.ZcashNetwork network = Nerdbank.Zcash.ZcashNetwork.MainNet) -> void
+Nerdbank.Zcash.TexAddress.TexAddress(in Nerdbank.Zcash.TexReceiver receiver, Nerdbank.Zcash.ZcashNetwork network = Nerdbank.Zcash.ZcashNetwork.MainNet) -> void
 Nerdbank.Zcash.TexAddress.TexAddress(Nerdbank.Zcash.TransparentP2PKHAddress! transparentAddress) -> void
+Nerdbank.Zcash.TexReceiver
+Nerdbank.Zcash.TexReceiver.Encode(System.Span<byte> buffer) -> int
+Nerdbank.Zcash.TexReceiver.EncodingLength.get -> int
+Nerdbank.Zcash.TexReceiver.Equals(Nerdbank.Zcash.TexReceiver other) -> bool
+Nerdbank.Zcash.TexReceiver.Pool.get -> Nerdbank.Zcash.Pool
+Nerdbank.Zcash.TexReceiver.Span.get -> System.ReadOnlySpan<byte>
+Nerdbank.Zcash.TexReceiver.TexReceiver() -> void
+Nerdbank.Zcash.TexReceiver.TexReceiver(Nerdbank.Zcash.Transparent.PublicKey! publicKey) -> void
+Nerdbank.Zcash.TexReceiver.TexReceiver(Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey! publicKey) -> void
+Nerdbank.Zcash.TexReceiver.TexReceiver(System.ReadOnlySpan<byte> p2pkh) -> void
+Nerdbank.Zcash.TexReceiver.ValidatingKeyHash.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.Transaction
 Nerdbank.Zcash.Transaction.Change.get -> System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.LineItem>
 Nerdbank.Zcash.Transaction.ExpiredUnmined.get -> bool
@@ -891,6 +902,8 @@ static Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryDecode(string! 
 static Nerdbank.Zcash.Sapling.FullViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.FullViewingKey? key) -> bool
 static Nerdbank.Zcash.Sapling.IncomingViewingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.IncomingViewingKey? key) -> bool
 static Nerdbank.Zcash.SaplingReceiver.UnifiedReceiverTypeCode.get -> byte
+static Nerdbank.Zcash.TexReceiver.explicit operator Nerdbank.Zcash.TransparentP2PKHReceiver(in Nerdbank.Zcash.TexReceiver receiver) -> Nerdbank.Zcash.TransparentP2PKHReceiver
+static Nerdbank.Zcash.TexReceiver.implicit operator Nerdbank.Zcash.TexReceiver(in Nerdbank.Zcash.TransparentP2PKHReceiver receiver) -> Nerdbank.Zcash.TexReceiver
 static Nerdbank.Zcash.Transaction.operator !=(Nerdbank.Zcash.Transaction? left, Nerdbank.Zcash.Transaction? right) -> bool
 static Nerdbank.Zcash.Transaction.operator ==(Nerdbank.Zcash.Transaction? left, Nerdbank.Zcash.Transaction? right) -> bool
 static Nerdbank.Zcash.Transaction.LineItem.operator !=(Nerdbank.Zcash.Transaction.LineItem left, Nerdbank.Zcash.Transaction.LineItem right) -> bool

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -420,6 +420,9 @@ Nerdbank.Zcash.SproutReceiver.Pool.get -> Nerdbank.Zcash.Pool
 Nerdbank.Zcash.SproutReceiver.Span.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SproutReceiver.SproutReceiver() -> void
 Nerdbank.Zcash.SproutReceiver.SproutReceiver(System.ReadOnlySpan<byte> apk, System.ReadOnlySpan<byte> pkEnc) -> void
+Nerdbank.Zcash.TexAddress
+Nerdbank.Zcash.TexAddress.TexAddress(in Nerdbank.Zcash.TransparentP2PKHReceiver receiver, Nerdbank.Zcash.ZcashNetwork network = Nerdbank.Zcash.ZcashNetwork.MainNet) -> void
+Nerdbank.Zcash.TexAddress.TexAddress(Nerdbank.Zcash.TransparentP2PKHAddress! transparentAddress) -> void
 Nerdbank.Zcash.Transaction
 Nerdbank.Zcash.Transaction.Change.get -> System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.LineItem>
 Nerdbank.Zcash.Transaction.ExpiredUnmined.get -> bool
@@ -775,6 +778,9 @@ override Nerdbank.Zcash.SaplingAddress.Network.get -> Nerdbank.Zcash.ZcashNetwor
 override Nerdbank.Zcash.SproutAddress.GetPoolReceiver<TPoolReceiver>() -> TPoolReceiver?
 override Nerdbank.Zcash.SproutAddress.HasShieldedReceiver.get -> bool
 override Nerdbank.Zcash.SproutAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
+override Nerdbank.Zcash.TexAddress.GetPoolReceiver<TPoolReceiver>() -> TPoolReceiver?
+override Nerdbank.Zcash.TexAddress.HasShieldedReceiver.get -> bool
+override Nerdbank.Zcash.TexAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
 override Nerdbank.Zcash.Transaction.Equals(object? obj) -> bool
 override Nerdbank.Zcash.Transaction.LineItem.GetHashCode() -> int
 override Nerdbank.Zcash.Transaction.GetHashCode() -> int

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -51,9 +51,10 @@ Nerdbank.Zcash.IPoolReceiver
 Nerdbank.Zcash.IPoolReceiver.Encode(System.Span<byte> buffer) -> int
 Nerdbank.Zcash.IPoolReceiver.EncodingLength.get -> int
 Nerdbank.Zcash.IPoolReceiver.Pool.get -> Nerdbank.Zcash.Pool
-Nerdbank.Zcash.IPoolReceiver.UnifiedReceiverTypeCode.get -> byte
 Nerdbank.Zcash.ISpendingKey
 Nerdbank.Zcash.ISpendingKey.FullViewingKey.get -> Nerdbank.Zcash.IFullViewingKey!
+Nerdbank.Zcash.IUnifiedPoolReceiver
+Nerdbank.Zcash.IUnifiedPoolReceiver.UnifiedReceiverTypeCode.get -> byte
 Nerdbank.Zcash.IZcashKey
 Nerdbank.Zcash.IZcashKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.LightWalletClient
@@ -884,7 +885,6 @@ static Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryDecode(string! 
 static Nerdbank.Zcash.Sapling.FullViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.FullViewingKey? key) -> bool
 static Nerdbank.Zcash.Sapling.IncomingViewingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.IncomingViewingKey? key) -> bool
 static Nerdbank.Zcash.SaplingReceiver.UnifiedReceiverTypeCode.get -> byte
-static Nerdbank.Zcash.SproutReceiver.UnifiedReceiverTypeCode.get -> byte
 static Nerdbank.Zcash.Transaction.operator !=(Nerdbank.Zcash.Transaction? left, Nerdbank.Zcash.Transaction? right) -> bool
 static Nerdbank.Zcash.Transaction.operator ==(Nerdbank.Zcash.Transaction? left, Nerdbank.Zcash.Transaction? right) -> bool
 static Nerdbank.Zcash.Transaction.LineItem.operator !=(Nerdbank.Zcash.Transaction.LineItem left, Nerdbank.Zcash.Transaction.LineItem right) -> bool

--- a/src/Nerdbank.Zcash/SaplingReceiver.cs
+++ b/src/Nerdbank.Zcash/SaplingReceiver.cs
@@ -9,7 +9,7 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Sapling"/> pool.
 /// </summary>
-public unsafe struct SaplingReceiver : IPoolReceiver
+public unsafe struct SaplingReceiver : IUnifiedPoolReceiver
 {
 	/// <summary>
 	/// Gets the number of bytes in a sapling receiver.
@@ -56,7 +56,7 @@ public unsafe struct SaplingReceiver : IPoolReceiver
 		receiver.CopyTo(this.SpanWritable);
 	}
 
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
+	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
 	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.Sapling;
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/SproutReceiver.cs
+++ b/src/Nerdbank.Zcash/SproutReceiver.cs
@@ -52,10 +52,6 @@ public unsafe struct SproutReceiver : IPoolReceiver
 		receiver.CopyTo(this.SpanWritable);
 	}
 
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
-	/// <exception cref="NotSupportedException">Always thrown because Unified Addresses do not support sprout receivers.</exception>
-	public static byte UnifiedReceiverTypeCode => throw new NotSupportedException();
-
 	/// <inheritdoc/>
 	public readonly Pool Pool => Pool.Sprout;
 

--- a/src/Nerdbank.Zcash/Strings.es.resx
+++ b/src/Nerdbank.Zcash/Strings.es.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddressDoesNotSupportUnifiedEncoding" xml:space="preserve">
+    <value>Este tipo de dirección no admite la codificación unificada.</value>
+  </data>
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Un niño endurecido no puede derivarse de una clave extendida pública. Utiliza una clave extendida privada en su lugar.</value>
   </data>

--- a/src/Nerdbank.Zcash/Strings.es.resx
+++ b/src/Nerdbank.Zcash/Strings.es.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Un niño endurecido no puede derivarse de una clave extendida pública. Utiliza una clave extendida privada en su lugar.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>Se produjo un error no asignado en la capa de interoperabilidad.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>Se ha producido un error al obtener metadatos del servidor lightwallet.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Una dirección de brote debe comenzar con 'zc' o 'zt'.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Error de análisis URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>Esta dirección {addressType} cumple con los requisitos esperados.</value>

--- a/src/Nerdbank.Zcash/Strings.fr.resx
+++ b/src/Nerdbank.Zcash/Strings.fr.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Un enfant durci ne peut pas être dérivé à partir d'une clé publique étendue. Utilisez plutôt une clé privée étendue.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>Une erreur non mappée s'est produite à travers la couche d'interopérabilité.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>Une erreur s'est produite lors de la récupération des métadonnées du serveur lightwallet.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Une adresse Sprout doit commencer par 'zc' ou 'zt'.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Analyse d'erreur URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>Cette adresse {addressType} ne respecte pas les exigences attendues.</value>

--- a/src/Nerdbank.Zcash/Strings.fr.resx
+++ b/src/Nerdbank.Zcash/Strings.fr.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddressDoesNotSupportUnifiedEncoding" xml:space="preserve">
+    <value>Ce type d'adresse ne prend pas en charge le codage unifié.</value>
+  </data>
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Un enfant durci ne peut pas être dérivé à partir d'une clé publique étendue. Utilisez plutôt une clé privée étendue.</value>
   </data>

--- a/src/Nerdbank.Zcash/Strings.ko.resx
+++ b/src/Nerdbank.Zcash/Strings.ko.resx
@@ -59,10 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root"
-    xmlns=""
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -123,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>하드닝된 자식은 공개 확장 키에서 파생될 수 없습니다. 대신 개인 확장 키를 사용하십시오.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>인터옵 계층을 통해 매핑되지 않은 오류가 발생했습니다.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>라이트월렛 서버에서 메타데이터를 가져오는 동안 오류가 발생했습니다.</value>
   </data>
@@ -161,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>스프라우트 주소는 'zc' 또는 'zt'로 시작해야 합니다.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>오류 파싱 URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>이 {addressType} 주소는 예상 요구 사항을 충족하지 않습니다.</value>

--- a/src/Nerdbank.Zcash/Strings.ko.resx
+++ b/src/Nerdbank.Zcash/Strings.ko.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddressDoesNotSupportUnifiedEncoding" xml:space="preserve">
+    <value>이 주소 유형은 통합 인코딩을 지원하지 않습니다.</value>
+  </data>
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>하드닝된 자식은 공개 확장 키에서 파생될 수 없습니다. 대신 개인 확장 키를 사용하십시오.</value>
   </data>

--- a/src/Nerdbank.Zcash/Strings.pt.resx
+++ b/src/Nerdbank.Zcash/Strings.pt.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Não é possível derivar uma chave filha endurecida de uma chave pública estendida. Use uma chave estendida privada em vez disso.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>Ocorreu um erro não mapeado na camada de interoperabilidade.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>Ocorreu um erro ao buscar metadados do servidor lightwallet.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Um endereço sprout deve começar com 'zc' ou 'zt'.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Erro analisando URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>Este endereço {addressType} não está em conformidade com os requisitos esperados.</value>

--- a/src/Nerdbank.Zcash/Strings.pt.resx
+++ b/src/Nerdbank.Zcash/Strings.pt.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddressDoesNotSupportUnifiedEncoding" xml:space="preserve">
+    <value>Este tipo de endereço não suporta codificação unificada.</value>
+  </data>
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Não é possível derivar uma chave filha endurecida de uma chave pública estendida. Use uma chave estendida privada em vez disso.</value>
   </data>

--- a/src/Nerdbank.Zcash/Strings.resx
+++ b/src/Nerdbank.Zcash/Strings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddressDoesNotSupportUnifiedEncoding" xml:space="preserve">
+    <value>This address type does not support unified encoding.</value>
+  </data>
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>A hardened child cannot be derived from a public extended key. Use a private extended key instead.</value>
   </data>

--- a/src/Nerdbank.Zcash/Strings.resx
+++ b/src/Nerdbank.Zcash/Strings.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>A hardened child cannot be derived from a public extended key. Use a private extended key instead.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>An unmapped error occurred across the interop layer.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>An error occurred while fetching metadata from the lightwallet server.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>A sprout address must start with 'zc' or 'zt'.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Error parsing URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>This {addressType} address does to conform to expected requirements.</value>

--- a/src/Nerdbank.Zcash/Strings.ru.resx
+++ b/src/Nerdbank.Zcash/Strings.ru.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Затвердевший ребенок не может быть получен из общественного расширенного ключа. Вместо этого используйте частный расширенный ключ.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>Ошибка неизменности произошла по всему слою взаимодействия.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>Произошла ошибка при извлечении метаданных с сервера Lightwallet.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Адрес раута должен начинаться с «zc» или «zt».</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Ошибка разбора URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>Этот адрес {addressType} соответствует ожидаемым требованиям.</value>

--- a/src/Nerdbank.Zcash/Strings.ru.resx
+++ b/src/Nerdbank.Zcash/Strings.ru.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddressDoesNotSupportUnifiedEncoding" xml:space="preserve">
+    <value>Этот тип адреса не поддерживает унифицированное кодирование.</value>
+  </data>
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Затвердевший ребенок не может быть получен из общественного расширенного ключа. Вместо этого используйте частный расширенный ключ.</value>
   </data>

--- a/src/Nerdbank.Zcash/Strings.zh-Hans.resx
+++ b/src/Nerdbank.Zcash/Strings.zh-Hans.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>无法从公共扩展密钥派生硬化子密钥。请使用私有扩展密钥。</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>在互操作层发生了一个未映射的错误。</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>从轻钱包服务器获取元数据时发生错误。</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Sprout 地址必须以 'zc' 或 'zt' 开头。</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>错误解析URI。</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>此 {addressType} 地址不符合预期要求。</value>

--- a/src/Nerdbank.Zcash/Strings.zh-Hans.resx
+++ b/src/Nerdbank.Zcash/Strings.zh-Hans.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddressDoesNotSupportUnifiedEncoding" xml:space="preserve">
+    <value>此地址类型不支持统一编码。</value>
+  </data>
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>无法从公共扩展密钥派生硬化子密钥。请使用私有扩展密钥。</value>
   </data>

--- a/src/Nerdbank.Zcash/TexAddress.cs
+++ b/src/Nerdbank.Zcash/TexAddress.cs
@@ -11,18 +11,18 @@ namespace Nerdbank.Zcash;
 /// <remarks>
 /// <para>TEX addresses are designed for use by exchanges that require transparently funded accounts for compliance purposes
 /// and so that they have an address to return rejected funds.</para>
-/// <para>The matching receiver type for this address is <see cref="TransparentP2PKHReceiver"/>.</para>
+/// <para>The matching receiver type for this address is <see cref="TexReceiver"/>.</para>
 /// <para>This implements <see href="https://zips.z.cash/zip-0320">ZIP-320</see>.</para>
 /// </remarks>
 public class TexAddress : TransparentAddress
 {
 	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-	private readonly TransparentP2PKHReceiver receiver;
+	private readonly TexReceiver receiver;
 	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 	private readonly ZcashNetwork network;
 
-	/// <inheritdoc cref="TexAddress(string, in TransparentP2PKHReceiver, ZcashNetwork)"/>
-	public TexAddress(in TransparentP2PKHReceiver receiver, ZcashNetwork network = ZcashNetwork.MainNet)
+	/// <inheritdoc cref="TexAddress(string, in TexReceiver, ZcashNetwork)"/>
+	public TexAddress(in TexReceiver receiver, ZcashNetwork network = ZcashNetwork.MainNet)
 		: base(CreateAddress(receiver, network))
 	{
 		this.receiver = receiver;
@@ -45,7 +45,7 @@ public class TexAddress : TransparentAddress
 	/// <param name="address"><inheritdoc cref="ZcashAddress(string)" path="/param"/></param>
 	/// <param name="receiver">The encoded receiver.</param>
 	/// <param name="network">The network to which this address belongs.</param>
-	internal TexAddress(string address, in TransparentP2PKHReceiver receiver, ZcashNetwork network)
+	internal TexAddress(string address, in TexReceiver receiver, ZcashNetwork network)
 		: base(address)
 	{
 		this.receiver = receiver;
@@ -65,7 +65,7 @@ public class TexAddress : TransparentAddress
 	internal override int ReceiverEncodingLength => this.receiver.EncodingLength;
 
 	/// <inheritdoc/>
-	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<TransparentP2PKHReceiver, TPoolReceiver>(this.receiver);
+	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<TexReceiver, TPoolReceiver>(this.receiver);
 
 	/// <summary>
 	/// Checks whether a given string looks like a Zcash TEX address.
@@ -107,7 +107,7 @@ public class TexAddress : TransparentAddress
 				return false;
 			}
 
-			result = new TexAddress(address, new TransparentP2PKHReceiver(data), network.Value);
+			result = new TexAddress(address, new TexReceiver(data), network.Value);
 			return true;
 		}
 
@@ -120,7 +120,7 @@ public class TexAddress : TransparentAddress
 	/// <inheritdoc/>
 	internal override int GetReceiverEncoding(Span<byte> output) => this.receiver.Encode(output);
 
-	private static string CreateAddress(in TransparentP2PKHReceiver receiver, ZcashNetwork network)
+	private static string CreateAddress(in TexReceiver receiver, ZcashNetwork network)
 	{
 		string hrp = network switch
 		{

--- a/src/Nerdbank.Zcash/TexAddress.cs
+++ b/src/Nerdbank.Zcash/TexAddress.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.Zcash;
+
+/// <summary>
+/// A transparent P2PKH address that has been encoded such that wallets should only send funds
+/// to this address in a transaction funded <em>only</em> by transparent funds.
+/// This means shielded funds must first be deshielded in a prior transaction before being sent to this address.
+/// </summary>
+/// <remarks>
+/// <para>TEX addresses are designed for use by exchanges that require transparently funded accounts for compliance purposes
+/// and so that they have an address to return rejected funds.</para>
+/// <para>The matching receiver type for this address is <see cref="TransparentP2PKHReceiver"/>.</para>
+/// <para>This implements <see href="https://zips.z.cash/zip-0320">ZIP-320</see>.</para>
+/// </remarks>
+public class TexAddress : TransparentAddress
+{
+	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+	private readonly TransparentP2PKHReceiver receiver;
+	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+	private readonly ZcashNetwork network;
+
+	/// <inheritdoc cref="TexAddress(string, in TransparentP2PKHReceiver, ZcashNetwork)"/>
+	public TexAddress(in TransparentP2PKHReceiver receiver, ZcashNetwork network = ZcashNetwork.MainNet)
+		: base(CreateAddress(receiver, network))
+	{
+		this.receiver = receiver;
+		this.network = network;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TexAddress"/> class
+	/// based on a <see cref="TransparentP2PKHAddress"/>.
+	/// </summary>
+	/// <param name="transparentAddress">The transparent address that should only receive funds from transactions funded by transparent sources.</param>
+	public TexAddress(TransparentP2PKHAddress transparentAddress)
+		: this(Requires.NotNull(transparentAddress).GetPoolReceiver<TransparentP2PKHReceiver>()!.Value, transparentAddress.Network)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TexAddress"/> class.
+	/// </summary>
+	/// <param name="address"><inheritdoc cref="ZcashAddress(string)" path="/param"/></param>
+	/// <param name="receiver">The encoded receiver.</param>
+	/// <param name="network">The network to which this address belongs.</param>
+	internal TexAddress(string address, in TransparentP2PKHReceiver receiver, ZcashNetwork network)
+		: base(address)
+	{
+		this.receiver = receiver;
+		this.network = network;
+	}
+
+	/// <inheritdoc/>
+	public override ZcashNetwork Network => this.network;
+
+	/// <inheritdoc/>
+	public override bool HasShieldedReceiver => false;
+
+	/// <inheritdoc/>
+	internal override byte UnifiedTypeCode => throw new NotSupportedException(Strings.AddressDoesNotSupportUnifiedEncoding);
+
+	/// <inheritdoc/>
+	internal override int ReceiverEncodingLength => this.receiver.EncodingLength;
+
+	/// <inheritdoc/>
+	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<TransparentP2PKHReceiver, TPoolReceiver>(this.receiver);
+
+	/// <summary>
+	/// Checks whether a given string looks like a Zcash TEX address.
+	/// </summary>
+	/// <param name="address">The address to test.</param>
+	/// <returns><see langword="true" /> if the address is likely a TEX address; otherwise <see langword="false" />.</returns>
+	internal static bool LooksLikeTexAddress(ReadOnlySpan<char> address)
+	{
+		return
+			(address.StartsWith(HumanReadablePart.MainNet, StringComparison.OrdinalIgnoreCase) && address[HumanReadablePart.MainNet.Length] == '1') ||
+			(address.StartsWith(HumanReadablePart.TestNet, StringComparison.OrdinalIgnoreCase) && address[HumanReadablePart.TestNet.Length] == '1');
+	}
+
+	/// <inheritdoc cref="ZcashAddress.TryDecode(string, out DecodeError?, out string?, out ZcashAddress?)" />
+	internal static bool TryParse(string address, [NotNullWhen(false)] out DecodeError? errorCode, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out TexAddress? result)
+	{
+		if (Bech32.GetDecodedLength(address) is (int tagLength, int dataLength))
+		{
+			Span<char> tag = stackalloc char[tagLength];
+			Span<byte> data = stackalloc byte[dataLength];
+			if (!Bech32.Bech32m.TryDecode(address, tag, data, out errorCode, out errorMessage, out _))
+			{
+				result = null;
+				return false;
+			}
+
+			ZcashNetwork? network = tag switch
+			{
+				HumanReadablePart.MainNet => ZcashNetwork.MainNet,
+				HumanReadablePart.TestNet => ZcashNetwork.TestNet,
+				_ => null,
+			};
+
+			if (network is null)
+			{
+				errorCode = DecodeError.UnrecognizedHRP;
+				errorMessage = $"Unexpected bech32 tag: {tag}";
+				result = null;
+				return false;
+			}
+
+			result = new TexAddress(address, new TransparentP2PKHReceiver(data), network.Value);
+			return true;
+		}
+
+		errorCode = DecodeError.UnrecognizedAddressType;
+		errorMessage = Strings.FormatInvalidXAddress("TEX");
+		result = null;
+		return false;
+	}
+
+	/// <inheritdoc/>
+	internal override int GetReceiverEncoding(Span<byte> output) => this.receiver.Encode(output);
+
+	private static string CreateAddress(in TransparentP2PKHReceiver receiver, ZcashNetwork network)
+	{
+		string hrp = network switch
+		{
+			ZcashNetwork.MainNet => HumanReadablePart.MainNet,
+			ZcashNetwork.TestNet => HumanReadablePart.TestNet,
+			_ => throw new NotSupportedException(Strings.FormatUnrecognizedNetwork(network)),
+		};
+		Span<char> addressChars = stackalloc char[Bech32.GetEncodedLength(hrp.Length, receiver.ValidatingKeyHash.Length)];
+		int charsLength = Bech32.Bech32m.Encode(hrp, receiver.ValidatingKeyHash, addressChars);
+		return addressChars[..charsLength].ToString();
+	}
+
+	private class HumanReadablePart
+	{
+		internal const string MainNet = "tex";
+		internal const string TestNet = "textest";
+	}
+}

--- a/src/Nerdbank.Zcash/TexReceiver.cs
+++ b/src/Nerdbank.Zcash/TexReceiver.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.Zcash;
+
+/// <summary>
+/// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Transparent"/> pool
+/// by way of a Pay to Public Key Hash method.
+/// </summary>
+/// <remarks>
+/// This receiver is used for <see cref="TexAddress"/> to represent receivers that must only be sent transparent funds.
+/// It is otherwise equivalent to <see cref="TransparentP2PKHReceiver"/>.
+/// </remarks>
+public unsafe struct TexReceiver : IPoolReceiver, IEquatable<TexReceiver>
+{
+	private readonly TransparentP2PKHReceiver p2pkhReceiver;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TexReceiver"/> struct.
+	/// </summary>
+	/// <param name="p2pkh">The validating key hash.</param>
+	/// <exception cref="ArgumentException">Thrown when the arguments have an unexpected length.</exception>
+	public TexReceiver(ReadOnlySpan<byte> p2pkh)
+	{
+		this.p2pkhReceiver = new(p2pkh);
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TexReceiver"/> struct.
+	/// </summary>
+	/// <param name="publicKey">The EC public key to create a receiver for.</param>
+	public TexReceiver(Zip32HDWallet.Transparent.ExtendedViewingKey publicKey)
+	{
+		this.p2pkhReceiver = new(publicKey);
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TexReceiver"/> struct.
+	/// </summary>
+	/// <param name="publicKey">The EC public key to create a receiver for.</param>
+	public TexReceiver(Transparent.PublicKey publicKey)
+	{
+		this.p2pkhReceiver = new(publicKey);
+	}
+
+	/// <inheritdoc/>
+	public readonly Pool Pool => Pool.Transparent;
+
+	/// <summary>
+	/// Gets the encoded representation of the entire receiver.
+	/// </summary>
+	[UnscopedRef]
+	public readonly ReadOnlySpan<byte> Span => this.ValidatingKeyHash;
+
+	/// <inheritdoc />
+	public readonly int EncodingLength => this.Span.Length;
+
+	/// <summary>
+	/// Gets the validating key hash.
+	/// </summary>
+	[UnscopedRef]
+	public readonly ReadOnlySpan<byte> ValidatingKeyHash => this.p2pkhReceiver.ValidatingKeyHash;
+
+	/// <summary>
+	/// Converts a <see cref="TransparentP2PKHReceiver"/> into a <see cref="TexReceiver" />.
+	/// </summary>
+	/// <param name="receiver">The receiver to convert from.</param>
+	public static implicit operator TexReceiver(in TransparentP2PKHReceiver receiver) => new(receiver.ValidatingKeyHash);
+
+	/// <summary>
+	/// Converts a <see cref="TexReceiver"/> into a <see cref="TransparentP2PKHReceiver" />.
+	/// </summary>
+	/// <param name="receiver">The receiver to convert from.</param>
+	public static explicit operator TransparentP2PKHReceiver(in TexReceiver receiver) => new(receiver.ValidatingKeyHash);
+
+	/// <inheritdoc/>
+	public int Encode(Span<byte> buffer) => this.Span.CopyToRetLength(buffer);
+
+	/// <inheritdoc/>
+	public bool Equals(TexReceiver other) => this.ValidatingKeyHash.SequenceEqual(other.ValidatingKeyHash);
+}

--- a/src/Nerdbank.Zcash/TransparentAddress.cs
+++ b/src/Nerdbank.Zcash/TransparentAddress.cs
@@ -6,13 +6,19 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A transparent Zcash address.
 /// </summary>
+/// <remarks>
+/// Not all transparent addresses carry the same semantics.
+/// For example, care should be taken when extracting a <see cref="TransparentP2PKHReceiver"/>
+/// to check whether the <see cref="TransparentAddress"/> is an instance of <see cref="TexAddress"/>,
+/// which should only receive funds from unshielded sources.
+/// </remarks>
 public abstract class TransparentAddress : ZcashAddress
 {
 	/// <summary>
 	/// Initializes a new instance of the <see cref="TransparentAddress"/> class.
 	/// </summary>
 	/// <param name="address"><inheritdoc cref="ZcashAddress(string)" path="/param"/></param>
-	public TransparentAddress(string address)
+	protected TransparentAddress(string address)
 		: base(address)
 	{
 	}
@@ -25,7 +31,13 @@ public abstract class TransparentAddress : ZcashAddress
 	/// <inheritdoc cref="ZcashAddress.TryDecode(string, out DecodeError?, out string?, out ZcashAddress?)" />
 	internal static bool TryParse(string address, [NotNullWhen(false)] out DecodeError? errorCode, [NotNullWhen(false)] out string? errorMessage, [NotNullWhen(true)] out TransparentAddress? result)
 	{
-		if (address.StartsWith("t", StringComparison.OrdinalIgnoreCase) && address.Length > 2)
+		if (TexAddress.LooksLikeTexAddress(address))
+		{
+			bool success = TexAddress.TryParse(address, out errorCode, out errorMessage, out TexAddress? texAddress);
+			result = texAddress;
+			return success;
+		}
+		else if (address.StartsWith("t", StringComparison.OrdinalIgnoreCase) && address.Length > 2)
 		{
 			Span<byte> decoded = stackalloc byte[DecodedLength];
 			if (!Base58Check.TryDecode(address, decoded, out errorCode, out errorMessage, out _))
@@ -37,8 +49,8 @@ public abstract class TransparentAddress : ZcashAddress
 #pragma warning disable SA1010 // Opening square brackets should be spaced correctly (https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3503)
 			ZcashNetwork? network = decoded[..2] switch
 			{
-				[0x1c, 0xbd] or [0x1c, 0xb8] => ZcashNetwork.MainNet,
-				[0x1c, 0xba] or [0x1d, 0x25] => ZcashNetwork.TestNet,
+			[0x1c, 0xbd] or [0x1c, 0xb8] => ZcashNetwork.MainNet,
+			[0x1c, 0xba] or [0x1d, 0x25] => ZcashNetwork.TestNet,
 				_ => null,
 			};
 
@@ -52,8 +64,8 @@ public abstract class TransparentAddress : ZcashAddress
 
 			result = decoded[..2] switch
 			{
-				[0x1c, 0xb8] or [0x1d, 0x25] => new TransparentP2PKHAddress(address, new TransparentP2PKHReceiver(decoded[2..]), network.Value),
-				[0x1c, 0xbd] or [0x1c, 0xba] => new TransparentP2SHAddress(address, new TransparentP2SHReceiver(decoded[2..]), network.Value),
+			[0x1c, 0xb8] or [0x1d, 0x25] => new TransparentP2PKHAddress(address, new TransparentP2PKHReceiver(decoded[2..]), network.Value),
+			[0x1c, 0xbd] or [0x1c, 0xba] => new TransparentP2SHAddress(address, new TransparentP2SHReceiver(decoded[2..]), network.Value),
 				_ => null,
 			};
 #pragma warning restore SA1010 // Opening square brackets should be spaced correctly

--- a/src/Nerdbank.Zcash/TransparentAddress.cs
+++ b/src/Nerdbank.Zcash/TransparentAddress.cs
@@ -6,12 +6,6 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A transparent Zcash address.
 /// </summary>
-/// <remarks>
-/// Not all transparent addresses carry the same semantics.
-/// For example, care should be taken when extracting a <see cref="TransparentP2PKHReceiver"/>
-/// to check whether the <see cref="TransparentAddress"/> is an instance of <see cref="TexAddress"/>,
-/// which should only receive funds from unshielded sources.
-/// </remarks>
 public abstract class TransparentAddress : ZcashAddress
 {
 	/// <summary>

--- a/src/Nerdbank.Zcash/TransparentP2PKHReceiver.cs
+++ b/src/Nerdbank.Zcash/TransparentP2PKHReceiver.cs
@@ -12,7 +12,7 @@ namespace Nerdbank.Zcash;
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Transparent"/> pool
 /// by way of a Pay to Public Key Hash method.
 /// </summary>
-public unsafe struct TransparentP2PKHReceiver : IPoolReceiver, IEquatable<TransparentP2PKHReceiver>
+public unsafe struct TransparentP2PKHReceiver : IUnifiedPoolReceiver, IEquatable<TransparentP2PKHReceiver>
 {
 	private const int Length = 160 / 8;
 
@@ -59,7 +59,7 @@ public unsafe struct TransparentP2PKHReceiver : IPoolReceiver, IEquatable<Transp
 		Assumes.True(Bitcoin.PublicKey.CreatePublicKeyHash(publicKey.KeyMaterial, this.ValidatingKeyHashWritable) == this.ValidatingKeyHashWritable.Length);
 	}
 
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
+	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
 	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.Sapling;
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/TransparentP2SHReceiver.cs
+++ b/src/Nerdbank.Zcash/TransparentP2SHReceiver.cs
@@ -10,7 +10,7 @@ namespace Nerdbank.Zcash;
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Transparent"/> pool
 /// by way of a Pay to Script Hash method.
 /// </summary>
-public unsafe struct TransparentP2SHReceiver : IPoolReceiver
+public unsafe struct TransparentP2SHReceiver : IUnifiedPoolReceiver
 {
 	private const int Length = 160 / 8;
 
@@ -34,7 +34,7 @@ public unsafe struct TransparentP2SHReceiver : IPoolReceiver
 	/// <summary>
 	/// Gets a span over the whole receiver.
 	/// </summary>
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
+	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
 	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.TransparentP2SH;
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/UnifiedAddress.cs
+++ b/src/Nerdbank.Zcash/UnifiedAddress.cs
@@ -8,6 +8,12 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A <see href="https://zips.z.cash/zip-0316">unified Zcash address</see>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Per <see href="https://zips.z.cash/zip-0316#requirements-for-both-unified-addresses-and-unified-viewing-keys">ZIP-316</see>,
+/// any abbreviation of this address for UI purposes MUST include at least the first 20 characters.
+/// </para>
+/// </remarks>
 public abstract class UnifiedAddress : ZcashAddress
 {
 	/// <summary>

--- a/src/Nerdbank.Zcash/ZcashAddress.cs
+++ b/src/Nerdbank.Zcash/ZcashAddress.cs
@@ -313,7 +313,7 @@ public abstract class ZcashAddress : IEquatable<ZcashAddress>, IUnifiedEncodingE
 	/// <param name="destination">The buffer to write to.</param>
 	/// <returns>The number of bytes actually written.</returns>
 	private protected static unsafe int WriteUAContribution<TReceiver>(in TReceiver receiver, Span<byte> destination)
-		where TReceiver : unmanaged, IPoolReceiver
+		where TReceiver : unmanaged, IUnifiedPoolReceiver
 	{
 		int bytesWritten = 0;
 		destination[bytesWritten++] = TReceiver.UnifiedReceiverTypeCode;

--- a/test/Nerdbank.Zcash.Tests/SproutReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/SproutReceiverTests.cs
@@ -43,10 +43,4 @@ public class SproutReceiverTests
 
 	[Fact]
 	public void Pool_Sprout() => Assert.Equal(Pool.Sprout, default(SproutReceiver).Pool);
-
-	[Fact]
-	public void UnifiedReceiverTypeCode_Throws()
-	{
-		Assert.Throws<NotSupportedException>(() => SproutReceiver.UnifiedReceiverTypeCode);
-	}
 }

--- a/test/Nerdbank.Zcash.Tests/TestBase.cs
+++ b/test/Nerdbank.Zcash.Tests/TestBase.cs
@@ -24,6 +24,7 @@ public abstract class TestBase
 	protected const string ValidSproutAddressTestNet = "ztJ1EWLKcGwF2S4NA17pAJVdco8Sdkz4AQPxt1cLTEfNuyNswJJc2BbBqYrsRZsp31xbVZwhF7c7a2L9jsF3p3ZwRWpqqyS";
 	protected const string ValidTransparentP2PKHAddress = "t1a7w3qM23i4ajQcbX5wd6oH4zTY8Bry5vF";
 	protected const string ValidTransparentP2SHAddress = "t3JZcvsuaXE6ygokL4XUiZSTrQBUoPYFnXJ";
+	protected const string ValidTexAddress = "tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte";
 
 	protected static readonly Uri LightWalletServerMainNet = new("https://mainnet.lightwalletd.com:9067/");
 

--- a/test/Nerdbank.Zcash.Tests/TexAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TexAddressTests.cs
@@ -15,6 +15,8 @@ public class TexAddressTests
 	{
 		var tex = (TexAddress)ZcashAddress.Decode("tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte");
 		var tAddr = (TransparentP2PKHAddress)ZcashAddress.Decode("t1VmmGiyjVNeCjxDZzg7vZmd99WyzVby9yC");
-		Assert.Equal(tAddr.GetPoolReceiver<TransparentP2PKHReceiver>(), tex.GetPoolReceiver<TransparentP2PKHReceiver>());
+		Assert.Equal(
+			tAddr.GetPoolReceiver<TransparentP2PKHReceiver>()!.Value.ValidatingKeyHash,
+			tex.GetPoolReceiver<TexReceiver>()!.Value.ValidatingKeyHash);
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/TexAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TexAddressTests.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public class TexAddressTests
+{
+	[Fact]
+	public void Ctor_FromTransparent()
+	{
+		TexAddress tex = new((TransparentP2PKHAddress)ZcashAddress.Decode("t1VmmGiyjVNeCjxDZzg7vZmd99WyzVby9yC"));
+		Assert.Equal("tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte", tex.Address);
+	}
+
+	[Fact]
+	public void SameReceiverAsTransparent()
+	{
+		var tex = (TexAddress)ZcashAddress.Decode("tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte");
+		var tAddr = (TransparentP2PKHAddress)ZcashAddress.Decode("t1VmmGiyjVNeCjxDZzg7vZmd99WyzVby9yC");
+		Assert.Equal(tAddr.GetPoolReceiver<TransparentP2PKHReceiver>(), tex.GetPoolReceiver<TransparentP2PKHReceiver>());
+	}
+}

--- a/test/Nerdbank.Zcash.Tests/TexReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TexReceiverTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public class TexReceiverTests
+{
+	[Fact]
+	public void Ctor()
+	{
+		byte[] hash = new byte[20];
+		hash[1] = 2;
+		TexReceiver receiver = new(hash);
+		Assert.Equal(hash, receiver.ValidatingKeyHash.ToArray());
+
+		// Verify that a copy of the data has been made.
+		hash[0] = 3;
+		Assert.Equal(0, receiver.ValidatingKeyHash[0]);
+	}
+
+	[Fact]
+	public void Ctor_ArgValidation()
+	{
+		Assert.Throws<ArgumentException>(() => new TexReceiver(new byte[1]));
+	}
+
+	[Fact]
+	public void Pool_Transparent() => Assert.Equal(Pool.Transparent, default(TexReceiver).Pool);
+
+	[Fact]
+	public void TexToTransparentConversion()
+	{
+		Span<byte> p2pkh = stackalloc byte[20];
+		Random.Shared.NextBytes(p2pkh);
+		TexReceiver texReceiver = new(p2pkh);
+		TransparentP2PKHReceiver transparentReceiver = (TransparentP2PKHReceiver)texReceiver;
+		Assert.Equal(texReceiver.ValidatingKeyHash, transparentReceiver.ValidatingKeyHash);
+	}
+
+	[Fact]
+	public void TransparentToTexConversion()
+	{
+		Span<byte> p2pkh = stackalloc byte[20];
+		Random.Shared.NextBytes(p2pkh);
+		TransparentP2PKHReceiver transparentReceiver = new(p2pkh);
+		TexReceiver texReceiver = transparentReceiver;
+		Assert.Equal(transparentReceiver.ValidatingKeyHash, texReceiver.ValidatingKeyHash);
+	}
+}

--- a/test/Nerdbank.Zcash.Tests/TransparentP2PKHReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2PKHReceiverTests.cs
@@ -23,7 +23,7 @@ public class TransparentP2PKHReceiverTests
 	}
 
 	[Fact]
-	public void Pool_Orchard() => Assert.Equal(Pool.Transparent, default(TransparentP2PKHReceiver).Pool);
+	public void Pool_Transparent() => Assert.Equal(Pool.Transparent, default(TransparentP2PKHReceiver).Pool);
 
 	[Fact]
 	public void UnifiedReceiverTypeCode() => Assert.Equal(0x02, TransparentP2PKHReceiver.UnifiedReceiverTypeCode);

--- a/test/Nerdbank.Zcash.Tests/TransparentP2SHReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2SHReceiverTests.cs
@@ -23,7 +23,7 @@ public class TransparentP2SHReceiverTests
 	}
 
 	[Fact]
-	public void Pool_Orchard() => Assert.Equal(Pool.Transparent, default(TransparentP2SHReceiver).Pool);
+	public void Pool_Transparent() => Assert.Equal(Pool.Transparent, default(TransparentP2SHReceiver).Pool);
 
 	[Fact]
 	public void UnifiedReceiverTypeCode() => Assert.Equal(0x01, TransparentP2SHReceiver.UnifiedReceiverTypeCode);

--- a/test/Nerdbank.Zcash.Tests/ZcashAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/ZcashAddressTests.cs
@@ -75,6 +75,7 @@ public class ZcashAddressTests : TestBase
 	[InlineData(ValidSproutAddress, typeof(SproutAddress))]
 	[InlineData(ValidTransparentP2PKHAddress, typeof(TransparentP2PKHAddress))]
 	[InlineData(ValidTransparentP2SHAddress, typeof(TransparentP2SHAddress))]
+	[InlineData(ValidTexAddress, typeof(TexAddress))]
 	public void Decode_ReturnsAppropriateType(string address, Type expectedKind)
 	{
 		var addr = ZcashAddress.Decode(address);


### PR DESCRIPTION
Add a new `TexAddress` class and `TexReceiver` struct, with tests and decoding hooks to match.

*Sending* to TEX addresses is not yet supported. This is **blocked** by a librustzcash update even newer than what #323 brings in because librustzcash does not yet support TEX addresses. https://github.com/zcash/librustzcash/issues/1403