### PR TITLE
Several CLI fixes and other touch-ups

### DIFF
--- a/src/Nerdbank.Zcash.Cli/AccountsCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/AccountsCommand.cs
@@ -16,6 +16,7 @@ internal class AccountsCommand : WalletUserCommandBase
 		Command command = new("accounts", Strings.AccountsCommandDescription)
 		{
 			WalletPathArgument,
+			TestNetOption,
 		};
 
 		command.SetHandler(async ctxt =>
@@ -24,6 +25,7 @@ internal class AccountsCommand : WalletUserCommandBase
 			{
 				Console = ctxt.Console,
 				WalletPath = ctxt.ParseResult.GetValueForArgument(WalletPathArgument),
+				TestNet = ctxt.ParseResult.GetValueForOption(TestNetOption),
 			}.ExecuteAsync(ctxt.GetCancellationToken());
 		});
 

--- a/src/Nerdbank.Zcash.Cli/ImportAccountCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/ImportAccountCommand.cs
@@ -30,7 +30,7 @@ internal class ImportAccountCommand
 		Option<ulong> birthdayHeightOption = new("--birthday-height", Strings.BirthdayHeightOptionDescription);
 		Option<Uri> lightServerUriOption = new("--lightserverUrl", Strings.LightServerUrlOptionDescription);
 
-		Command command = new("ImportAccount", Strings.ImportAccountCommandDescription)
+		Command command = new("import", Strings.ImportAccountCommandDescription)
 		{
 			keyArgument,
 			walletPathOption,

--- a/src/Nerdbank.Zcash.Cli/NewAccountCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/NewAccountCommand.cs
@@ -66,7 +66,7 @@ internal class NewAccountCommand
 
 		Option<ulong> birthdayHeightOption = new("--birthday-height", Strings.BirthdayHeightOptionDescription);
 
-		Command command = new("NewAccount", Strings.NewAccountCommandDescription)
+		Command command = new("new", Strings.NewAccountCommandDescription)
 		{
 			seedPhraseWordLengthOption,
 			seedPhraseOption,

--- a/src/Nerdbank.Zcash.Cli/NewAccountCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/NewAccountCommand.cs
@@ -53,11 +53,7 @@ internal class NewAccountCommand
 
 		Option<string> seedPhrasePasswordOption = new("--password", Strings.PasswordOptionDescription);
 
-		Option<bool> testNetOption = new("--testnet", Strings.TestNetOptionDescription);
-
 		Option<uint> accountIndexOption = new("--index", () => 0, Strings.AccountIndexOptionDescription);
-
-		Option<Uri> lightServerUriOption = new("--lightserverUrl", Strings.LightServerUrlOptionDescription);
 
 		Option<bool> offlineModeOption = new("--offline", Strings.OfflineOptionDescription);
 
@@ -71,9 +67,9 @@ internal class NewAccountCommand
 			seedPhraseWordLengthOption,
 			seedPhraseOption,
 			seedPhrasePasswordOption,
-			testNetOption,
+			WalletUserCommandBase.TestNetOption,
 			accountIndexOption,
-			lightServerUriOption,
+			WalletUserCommandBase.LightServerUriOption,
 			offlineModeOption,
 			walletPathOption,
 			birthdayHeightOption,
@@ -96,9 +92,9 @@ internal class NewAccountCommand
 				SeedPhrase = ctxt.ParseResult.GetValueForOption(seedPhraseOption),
 				PromptForSeedPhrase = ctxt.ParseResult.FindResultFor(seedPhraseOption) is { Token: not null, Tokens: { Count: 0 } },
 				Password = ctxt.ParseResult.GetValueForOption(seedPhrasePasswordOption),
-				TestNet = ctxt.ParseResult.GetValueForOption(testNetOption),
+				TestNet = ctxt.ParseResult.GetValueForOption(WalletUserCommandBase.TestNetOption),
 				AccountIndex = ctxt.ParseResult.GetValueForOption(accountIndexOption),
-				LightWalletServerUrl = ctxt.ParseResult.GetValueForOption(lightServerUriOption),
+				LightWalletServerUrl = ctxt.ParseResult.GetValueForOption(WalletUserCommandBase.LightServerUriOption),
 				OfflineMode = ctxt.ParseResult.GetValueForOption(offlineModeOption),
 				WalletPath = ctxt.ParseResult.GetValueForOption(walletPathOption),
 				BirthdayHeight = ctxt.ParseResult.GetValueForOption(birthdayHeightOption),

--- a/src/Nerdbank.Zcash.Cli/RequestPaymentCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/RequestPaymentCommand.cs
@@ -34,7 +34,7 @@ internal class RequestPaymentCommand
 		Option<string[]> messagesOption = new("--message", Strings.RequestPaymentMessageOptionDescription) { Arity = ArgumentArity.OneOrMore };
 		Option<string> saveQRCodeOption = new Option<string>("--output", Strings.RequestPaymentSaveQRCodeOption).LegalFilePathsOnly();
 
-		Command command = new("RequestPayment", Strings.RequestPaymentCommandDescription)
+		Command command = new("invoice", Strings.RequestPaymentCommandDescription)
 		{
 			payeesArgument,
 			amountsOption,

--- a/src/Nerdbank.Zcash.Cli/SendCommand.cs
+++ b/src/Nerdbank.Zcash.Cli/SendCommand.cs
@@ -61,7 +61,7 @@ internal class SendCommand : SyncFirstCommandBase
 		}
 
 		Transaction.LineItem item = new(this.Recipient, this.Amount, Zcash.Memo.FromMessage(this.Memo));
-		ReadOnlyMemory<TxId> txid = await client.SendAsync(
+		ReadOnlyMemory<TxId> txids = await client.SendAsync(
 			this.SelectedAccount!,
 			[item],
 			new Progress<LightWalletClient.SendProgress>(p =>
@@ -73,7 +73,10 @@ internal class SendCommand : SyncFirstCommandBase
 			}),
 			cancellationToken);
 
-		this.Console.WriteLine($"Transmitted transaction ID: {txid}");
+		for (int i = 0; i < txids.Length; i++)
+		{
+			this.Console.WriteLine($"Transmitted transaction ID: {txids.Span[i]}");
+		}
 
 		return 0;
 	}

--- a/src/Nerdbank.Zcash.Cli/WalletUserCommandBase.cs
+++ b/src/Nerdbank.Zcash.Cli/WalletUserCommandBase.cs
@@ -22,6 +22,10 @@ internal abstract class WalletUserCommandBase
 		this.LightWalletServerUrl = copyFrom.LightWalletServerUrl;
 	}
 
+	internal static Option<bool> TestNetOption { get; } = new("--testnet", Strings.TestNetOptionDescription);
+
+	internal static Option<Uri> LightServerUriOption { get; } = new("--lightserverUrl", Strings.LightServerUrlOptionDescription);
+
 	internal required IConsole Console { get; init; }
 
 	internal required string WalletPath { get; init; }
@@ -39,10 +43,6 @@ internal abstract class WalletUserCommandBase
 	internal uint SpendingKeyAccountIndex { get; init; }
 
 	protected static Argument<string> WalletPathArgument { get; } = new Argument<string>("wallet path", Strings.WalletPathArgumentDescription).LegalFilePathsOnly();
-
-	protected static Option<bool> TestNetOption { get; } = new("--testnet", Strings.TestNetOptionDescription);
-
-	protected static Option<Uri> LightServerUriOption { get; } = new("--lightserverUrl", Strings.LightServerUrlOptionDescription);
 
 	protected static Option<ZcashAddress> OptionalSelectedAccountOption { get; } = new("--account", parseArgument: arg => ZcashAddress.Decode(arg.Tokens[0].Value), description: Strings.SelectedAccountArgumentDescription);
 

--- a/src/Nerdbank.Zcash/IPoolReceiver.cs
+++ b/src/Nerdbank.Zcash/IPoolReceiver.cs
@@ -9,11 +9,6 @@ namespace Nerdbank.Zcash;
 public interface IPoolReceiver
 {
 	/// <summary>
-	/// Gets the type code that identifies the type of receiver in a Unified Address.
-	/// </summary>
-	static abstract byte UnifiedReceiverTypeCode { get; }
-
-	/// <summary>
 	/// Gets the pool that this receiver can send funds into.
 	/// </summary>
 	Pool Pool { get; }

--- a/src/Nerdbank.Zcash/IUnifiedPoolReceiver.cs
+++ b/src/Nerdbank.Zcash/IUnifiedPoolReceiver.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.Zcash;
+
+/// <summary>
+/// An interface implemented by receivers that are embedded in Zcash addresses
+/// that are allowed in unified addresses.
+/// </summary>
+public interface IUnifiedPoolReceiver : IPoolReceiver
+{
+	/// <summary>
+	/// Gets the type code that identifies the type of receiver in a Unified Address.
+	/// </summary>
+	static abstract byte UnifiedReceiverTypeCode { get; }
+}

--- a/src/Nerdbank.Zcash/OrchardReceiver.cs
+++ b/src/Nerdbank.Zcash/OrchardReceiver.cs
@@ -9,7 +9,7 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Orchard"/> pool.
 /// </summary>
-public unsafe struct OrchardReceiver : IPoolReceiver
+public unsafe struct OrchardReceiver : IUnifiedPoolReceiver
 {
 	private const int DLength = 88 / 8;
 	private const int PkdLength = 256 / 8;
@@ -53,7 +53,7 @@ public unsafe struct OrchardReceiver : IPoolReceiver
 		receiver.CopyTo(this.SpanWritable);
 	}
 
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
+	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
 	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.Orchard;
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -51,9 +51,10 @@ Nerdbank.Zcash.IPoolReceiver
 Nerdbank.Zcash.IPoolReceiver.Encode(System.Span<byte> buffer) -> int
 Nerdbank.Zcash.IPoolReceiver.EncodingLength.get -> int
 Nerdbank.Zcash.IPoolReceiver.Pool.get -> Nerdbank.Zcash.Pool
-Nerdbank.Zcash.IPoolReceiver.UnifiedReceiverTypeCode.get -> byte
 Nerdbank.Zcash.ISpendingKey
 Nerdbank.Zcash.ISpendingKey.FullViewingKey.get -> Nerdbank.Zcash.IFullViewingKey!
+Nerdbank.Zcash.IUnifiedPoolReceiver
+Nerdbank.Zcash.IUnifiedPoolReceiver.UnifiedReceiverTypeCode.get -> byte
 Nerdbank.Zcash.IZcashKey
 Nerdbank.Zcash.IZcashKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.LightWalletClient
@@ -884,7 +885,6 @@ static Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryDecode(string! 
 static Nerdbank.Zcash.Sapling.FullViewingKey.TryDecode(string! encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.FullViewingKey? key) -> bool
 static Nerdbank.Zcash.Sapling.IncomingViewingKey.TryDecode(System.ReadOnlySpan<char> encoding, out Nerdbank.Cryptocurrencies.DecodeError? decodeError, out string? errorMessage, out Nerdbank.Zcash.Sapling.IncomingViewingKey? key) -> bool
 static Nerdbank.Zcash.SaplingReceiver.UnifiedReceiverTypeCode.get -> byte
-static Nerdbank.Zcash.SproutReceiver.UnifiedReceiverTypeCode.get -> byte
 static Nerdbank.Zcash.Transaction.operator !=(Nerdbank.Zcash.Transaction? left, Nerdbank.Zcash.Transaction? right) -> bool
 static Nerdbank.Zcash.Transaction.operator ==(Nerdbank.Zcash.Transaction? left, Nerdbank.Zcash.Transaction? right) -> bool
 static Nerdbank.Zcash.Transaction.LineItem.operator !=(Nerdbank.Zcash.Transaction.LineItem left, Nerdbank.Zcash.Transaction.LineItem right) -> bool

--- a/src/Nerdbank.Zcash/SaplingReceiver.cs
+++ b/src/Nerdbank.Zcash/SaplingReceiver.cs
@@ -9,7 +9,7 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Sapling"/> pool.
 /// </summary>
-public unsafe struct SaplingReceiver : IPoolReceiver
+public unsafe struct SaplingReceiver : IUnifiedPoolReceiver
 {
 	/// <summary>
 	/// Gets the number of bytes in a sapling receiver.
@@ -56,7 +56,7 @@ public unsafe struct SaplingReceiver : IPoolReceiver
 		receiver.CopyTo(this.SpanWritable);
 	}
 
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
+	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
 	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.Sapling;
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/SproutReceiver.cs
+++ b/src/Nerdbank.Zcash/SproutReceiver.cs
@@ -52,10 +52,6 @@ public unsafe struct SproutReceiver : IPoolReceiver
 		receiver.CopyTo(this.SpanWritable);
 	}
 
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
-	/// <exception cref="NotSupportedException">Always thrown because Unified Addresses do not support sprout receivers.</exception>
-	public static byte UnifiedReceiverTypeCode => throw new NotSupportedException();
-
 	/// <inheritdoc/>
 	public readonly Pool Pool => Pool.Sprout;
 

--- a/src/Nerdbank.Zcash/Strings.es.resx
+++ b/src/Nerdbank.Zcash/Strings.es.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Un niño endurecido no puede derivarse de una clave extendida pública. Utiliza una clave extendida privada en su lugar.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>Se produjo un error no asignado en la capa de interoperabilidad.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>Se ha producido un error al obtener metadatos del servidor lightwallet.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Una dirección de brote debe comenzar con 'zc' o 'zt'.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Error de análisis URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>Esta dirección {addressType} cumple con los requisitos esperados.</value>

--- a/src/Nerdbank.Zcash/Strings.fr.resx
+++ b/src/Nerdbank.Zcash/Strings.fr.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Un enfant durci ne peut pas être dérivé à partir d'une clé publique étendue. Utilisez plutôt une clé privée étendue.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>Une erreur non mappée s'est produite à travers la couche d'interopérabilité.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>Une erreur s'est produite lors de la récupération des métadonnées du serveur lightwallet.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Une adresse Sprout doit commencer par 'zc' ou 'zt'.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Analyse d'erreur URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>Cette adresse {addressType} ne respecte pas les exigences attendues.</value>

--- a/src/Nerdbank.Zcash/Strings.ko.resx
+++ b/src/Nerdbank.Zcash/Strings.ko.resx
@@ -59,10 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root"
-    xmlns=""
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -123,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>하드닝된 자식은 공개 확장 키에서 파생될 수 없습니다. 대신 개인 확장 키를 사용하십시오.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>인터옵 계층을 통해 매핑되지 않은 오류가 발생했습니다.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>라이트월렛 서버에서 메타데이터를 가져오는 동안 오류가 발생했습니다.</value>
   </data>
@@ -161,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>스프라우트 주소는 'zc' 또는 'zt'로 시작해야 합니다.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>오류 파싱 URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>이 {addressType} 주소는 예상 요구 사항을 충족하지 않습니다.</value>

--- a/src/Nerdbank.Zcash/Strings.pt.resx
+++ b/src/Nerdbank.Zcash/Strings.pt.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Não é possível derivar uma chave filha endurecida de uma chave pública estendida. Use uma chave estendida privada em vez disso.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>Ocorreu um erro não mapeado na camada de interoperabilidade.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>Ocorreu um erro ao buscar metadados do servidor lightwallet.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Um endereço sprout deve começar com 'zc' ou 'zt'.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Erro analisando URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>Este endereço {addressType} não está em conformidade com os requisitos esperados.</value>

--- a/src/Nerdbank.Zcash/Strings.resx
+++ b/src/Nerdbank.Zcash/Strings.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>A hardened child cannot be derived from a public extended key. Use a private extended key instead.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>An unmapped error occurred across the interop layer.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>An error occurred while fetching metadata from the lightwallet server.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>A sprout address must start with 'zc' or 'zt'.</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Error parsing URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>This {addressType} address does to conform to expected requirements.</value>

--- a/src/Nerdbank.Zcash/Strings.ru.resx
+++ b/src/Nerdbank.Zcash/Strings.ru.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>Затвердевший ребенок не может быть получен из общественного расширенного ключа. Вместо этого используйте частный расширенный ключ.</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>Ошибка неизменности произошла по всему слою взаимодействия.</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>Произошла ошибка при извлечении метаданных с сервера Lightwallet.</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Адрес раута должен начинаться с «zc» или «zt».</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>Ошибка разбора URI.</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>Этот адрес {addressType} соответствует ожидаемым требованиям.</value>

--- a/src/Nerdbank.Zcash/Strings.zh-Hans.resx
+++ b/src/Nerdbank.Zcash/Strings.zh-Hans.resx
@@ -120,9 +120,6 @@
   <data name="CannotDeriveHardenedChildFromPublicKey" xml:space="preserve">
     <value>无法从公共扩展密钥派生硬化子密钥。请使用私有扩展密钥。</value>
   </data>
-  <data name="ErrorFromNativeSide" xml:space="preserve">
-    <value>在互操作层发生了一个未映射的错误。</value>
-  </data>
   <data name="ErrorInGetLightWalletServerInfo" xml:space="preserve">
     <value>从轻钱包服务器获取元数据时发生错误。</value>
   </data>
@@ -158,6 +155,9 @@
   </data>
   <data name="InvalidSproutPreamble" xml:space="preserve">
     <value>Sprout 地址必须以 'zc' 或 'zt' 开头。</value>
+  </data>
+  <data name="InvalidUri" xml:space="preserve">
+    <value>错误解析URI。</value>
   </data>
   <data name="InvalidXAddress" xml:space="preserve">
     <value>此 {addressType} 地址不符合预期要求。</value>

--- a/src/Nerdbank.Zcash/TransparentP2PKHReceiver.cs
+++ b/src/Nerdbank.Zcash/TransparentP2PKHReceiver.cs
@@ -12,7 +12,7 @@ namespace Nerdbank.Zcash;
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Transparent"/> pool
 /// by way of a Pay to Public Key Hash method.
 /// </summary>
-public unsafe struct TransparentP2PKHReceiver : IPoolReceiver, IEquatable<TransparentP2PKHReceiver>
+public unsafe struct TransparentP2PKHReceiver : IUnifiedPoolReceiver, IEquatable<TransparentP2PKHReceiver>
 {
 	private const int Length = 160 / 8;
 
@@ -59,7 +59,7 @@ public unsafe struct TransparentP2PKHReceiver : IPoolReceiver, IEquatable<Transp
 		Assumes.True(Bitcoin.PublicKey.CreatePublicKeyHash(publicKey.KeyMaterial, this.ValidatingKeyHashWritable) == this.ValidatingKeyHashWritable.Length);
 	}
 
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
+	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
 	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.Sapling;
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/TransparentP2SHReceiver.cs
+++ b/src/Nerdbank.Zcash/TransparentP2SHReceiver.cs
@@ -10,7 +10,7 @@ namespace Nerdbank.Zcash;
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Transparent"/> pool
 /// by way of a Pay to Script Hash method.
 /// </summary>
-public unsafe struct TransparentP2SHReceiver : IPoolReceiver
+public unsafe struct TransparentP2SHReceiver : IUnifiedPoolReceiver
 {
 	private const int Length = 160 / 8;
 
@@ -34,7 +34,7 @@ public unsafe struct TransparentP2SHReceiver : IPoolReceiver
 	/// <summary>
 	/// Gets a span over the whole receiver.
 	/// </summary>
-	/// <inheritdoc cref="IPoolReceiver.UnifiedReceiverTypeCode"/>
+	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
 	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.TransparentP2SH;
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.Zcash/UnifiedAddress.cs
+++ b/src/Nerdbank.Zcash/UnifiedAddress.cs
@@ -8,6 +8,12 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A <see href="https://zips.z.cash/zip-0316">unified Zcash address</see>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Per <see href="https://zips.z.cash/zip-0316#requirements-for-both-unified-addresses-and-unified-viewing-keys">ZIP-316</see>,
+/// any abbreviation of this address for UI purposes MUST include at least the first 20 characters.
+/// </para>
+/// </remarks>
 public abstract class UnifiedAddress : ZcashAddress
 {
 	/// <summary>

--- a/src/Nerdbank.Zcash/ZcashAddress.cs
+++ b/src/Nerdbank.Zcash/ZcashAddress.cs
@@ -313,7 +313,7 @@ public abstract class ZcashAddress : IEquatable<ZcashAddress>, IUnifiedEncodingE
 	/// <param name="destination">The buffer to write to.</param>
 	/// <returns>The number of bytes actually written.</returns>
 	private protected static unsafe int WriteUAContribution<TReceiver>(in TReceiver receiver, Span<byte> destination)
-		where TReceiver : unmanaged, IPoolReceiver
+		where TReceiver : unmanaged, IUnifiedPoolReceiver
 	{
 		int bytesWritten = 0;
 		destination[bytesWritten++] = TReceiver.UnifiedReceiverTypeCode;

--- a/test/Nerdbank.Zcash.Tests/SproutReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/SproutReceiverTests.cs
@@ -43,10 +43,4 @@ public class SproutReceiverTests
 
 	[Fact]
 	public void Pool_Sprout() => Assert.Equal(Pool.Sprout, default(SproutReceiver).Pool);
-
-	[Fact]
-	public void UnifiedReceiverTypeCode_Throws()
-	{
-		Assert.Throws<NotSupportedException>(() => SproutReceiver.UnifiedReceiverTypeCode);
-	}
 }


### PR DESCRIPTION
This pull request includes changes to the `Nerdbank.Zcash.Cli` and `Nerdbank.Zcash` namespaces, primarily focusing on the restructuring of command building in the CLI, introducing the `IUnifiedPoolReceiver` interface, and improving error handling. The most important changes include the addition of the `TestNetOption` and `LightServerUriOption` as static properties in `WalletUserCommandBase`, changes to command names and options in various `BuildCommand()` methods, and the introduction of the `IUnifiedPoolReceiver` interface.

Command building in the CLI:

* [`src/Nerdbank.Zcash.Cli/AccountsCommand.cs`](diffhunk://#diff-ebe3c5c6c8a0018ef5479391aa1410883de7270542e4e287e72a27968bb81a81R19): Added `TestNetOption` to the command and its execution in `BuildCommand()`. [[1]](diffhunk://#diff-ebe3c5c6c8a0018ef5479391aa1410883de7270542e4e287e72a27968bb81a81R19) [[2]](diffhunk://#diff-ebe3c5c6c8a0018ef5479391aa1410883de7270542e4e287e72a27968bb81a81R28)
* [`src/Nerdbank.Zcash.Cli/ImportAccountCommand.cs`](diffhunk://#diff-1f3f4206d15d6f7d462241787f6cacc1943431751ebd569a420041397bc49f07L33-R33): Changed the command name from "ImportAccount" to "import" in `BuildCommand()`.
* [`src/Nerdbank.Zcash.Cli/NewAccountCommand.cs`](diffhunk://#diff-04cc8497536a3b011ef20d200ba51307b6dc780d979886018f40a70ce3bb574eL56-R72): Changed the command name from "NewAccount" to "new", removed `testNetOption` and `lightServerUriOption`, and replaced them with `WalletUserCommandBase.TestNetOption` and `WalletUserCommandBase.LightServerUriOption` in `BuildCommand()`. [[1]](diffhunk://#diff-04cc8497536a3b011ef20d200ba51307b6dc780d979886018f40a70ce3bb574eL56-R72) [[2]](diffhunk://#diff-04cc8497536a3b011ef20d200ba51307b6dc780d979886018f40a70ce3bb574eL99-R97)
* [`src/Nerdbank.Zcash.Cli/RequestPaymentCommand.cs`](diffhunk://#diff-22fee32d2209431190d3d4d4a889f3c7e168cdcc7f508e1885d46ddde6f5137eL37-R37): Changed the command name from "RequestPayment" to "invoice" in `BuildCommand()`.

Introduction of `IUnifiedPoolReceiver` interface:

* [`src/Nerdbank.Zcash/IPoolReceiver.cs`](diffhunk://#diff-234f2703825a52b7b10427c3fdba1be5036ef41fff75b2495beed9776305c660L11-L15): Removed `UnifiedReceiverTypeCode` property from `IPoolReceiver` interface.
* [`src/Nerdbank.Zcash/IUnifiedPoolReceiver.cs`](diffhunk://#diff-4009fc621cc6c4e4b0a5e2f827138e24185f18dfc1620d4f0d0179d623870daeR1-R16): Added new `IUnifiedPoolReceiver` interface with `UnifiedReceiverTypeCode` property.
* [`src/Nerdbank.Zcash/OrchardReceiver.cs`](diffhunk://#diff-89817244366e2247815a6c6c0e710b2de50ac69650bd932387996dffcc218267L12-R12): Changed `OrchardReceiver` to implement `IUnifiedPoolReceiver` instead of `IPoolReceiver`. [[1]](diffhunk://#diff-89817244366e2247815a6c6c0e710b2de50ac69650bd932387996dffcc218267L12-R12) [[2]](diffhunk://#diff-89817244366e2247815a6c6c0e710b2de50ac69650bd932387996dffcc218267L56-R56)
* [`src/Nerdbank.Zcash/SaplingReceiver.cs`](diffhunk://#diff-8c4c4350cbeb8ee398491e4a575d0185331415ef93b359d416b1b5dc49a2dba9L12-R12): Changed `SaplingReceiver` to implement `IUnifiedPoolReceiver` instead of `IPoolReceiver`. [[1]](diffhunk://#diff-8c4c4350cbeb8ee398491e4a575d0185331415ef93b359d416b1b5dc49a2dba9L12-R12) [[2]](diffhunk://#diff-8c4c4350cbeb8ee398491e4a575d0185331415ef93b359d416b1b5dc49a2dba9L59-R59)
* [`src/Nerdbank.Zcash/SproutReceiver.cs`](diffhunk://#diff-6d54a1ae4abda81e7d2231f5c4bfe0ee0e94889dd84114d385c86798e02df2e1L55-L58): Removed unsupported `UnifiedReceiverTypeCode` property from `SproutReceiver`.

Error handling improvements:

* [`src/Nerdbank.Zcash/LightWalletClient.cs`](diffhunk://#diff-8ab7360cebac85d45d95fde2ebb7cde7c34a6748f9f383054e63c9d2350de70fL485-R487): Simplified error handling in `InvokeInterop()` and `ReadAccountsFromDatabase()` by using `LightWalletException.Wrap()`. [[1]](diffhunk://#diff-8ab7360cebac85d45d95fde2ebb7cde7c34a6748f9f383054e63c9d2350de70fL485-R487) [[2]](diffhunk://#diff-8ab7360cebac85d45d95fde2ebb7cde7c34a6748f9f383054e63c9d2350de70fL524-R506) [[3]](diffhunk://#diff-8ab7360cebac85d45d95fde2ebb7cde7c34a6748f9f383054e63c9d2350de70fR518-R522)
* [`src/Nerdbank.Zcash/LightWalletException.cs`](diffhunk://#diff-cd1389176d746fabf5119752ed6fbdc753d032c03175c78bcd63e4652437c0d1R67-L85): Updated `Wrap()` method to return different exceptions based on the type of `LightWalletException`, including a `OperationCanceledException` for cancellations.

Other changes:

* [`src/Nerdbank.Zcash.Cli/WalletUserCommandBase.cs`](diffhunk://#diff-51161abdd4608262a842412685695fb2e48fa620c08d99cd721cfacaeea2ebc9R25-R28): Added `TestNetOption` and `LightServerUriOption` as static properties, replacing the previous instance properties. [[1]](diffhunk://#diff-51161abdd4608262a842412685695fb2e48fa620c08d99cd721cfacaeea2ebc9R25-R28) [[2]](diffhunk://#diff-51161abdd4608262a842412685695fb2e48fa620c08d99cd721cfacaeea2ebc9L43-L46)
* [`src/Nerdbank.Zcash.Cli/SendCommand.cs`](diffhunk://#diff-4da9a61b053d32500ee737bb82114c8d676ce06bb1a81698c6832f9399a9351aL64-R64): Changed `txid` to `txids` and added a loop to print all transmitted transaction IDs in `ExecuteAsync()`. [[1]](diffhunk://#diff-4da9a61b053d32500ee737bb82114c8d676ce06bb1a81698c6832f9399a9351aL64-R64) [[2]](diffhunk://#diff-4da9a61b053d32500ee737bb82114c8d676ce06bb1a81698c6832f9399a9351aL76-R79)
* [`src/Nerdbank.Zcash/PublicAPI.Unshipped.txt`](diffhunk://#diff-a23f3c4c4a1dd19d4941157f9f1c79526e5590bfe5210083a6d38dfb082472f9L887): Updated public API changes to reflect the changes in the interfaces and classes. (F0e58c35L120R120, [src/Nerdbank.Zcash/PublicAPI.Unshipped.txtL887](diffhunk://#diff-a23f3c4c4a1dd19d4941157f9f1c79526e5590bfe5210083a6d38dfb082472f9L887))
* `src/Nerdbank.Zcash/Strings.es.resx` and `src/Nerdbank.Zcash/Strings.fr.resx`: Removed "ErrorFromNativeSide" and added "InvalidUri" in the resource files. [[1]](diffhunk://#diff-72006e9047cee04d015134f0591be348b15d20f6e0ce99719e8dc31fe332fd7eL123-L125) [[2]](diffhunk://#diff-72006e9047cee04d015134f0591be348b15d20f6e0ce99719e8dc31fe332fd7eR159-R161) [[3]](diffhunk://#diff-f4d0fc0c5c4fac0bdaa777a25f11fa1ac307a85f24a14488942422a734fdf2c6L123-L125)