### PR TITLE
Merge latest Library.Template

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.27.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.63.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.63.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.64.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />
     <PackageVersion Include="Isopoh.Cryptography.Blake2b" Version="2.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <RoslynVersion>3.11.0-beta1.24104.1</RoslynVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.3.1" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.27.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.63.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.63.0" />


### PR DESCRIPTION
- Bump dotnet-coverage from 17.11.0 to 17.11.3 (#272)
- Bump Nerdbank.GitVersioning to 3.6.139
- Bump nbgv to 3.6.139
