### PR TITLE
Fix unstable `ZcashAddress.IsMatch_PartialMatch` test

### DIFF
--- a/src/Nerdbank.Zcash/OrchardReceiver.cs
+++ b/src/Nerdbank.Zcash/OrchardReceiver.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Nerdbank.Zcash;
@@ -9,7 +8,7 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Orchard"/> pool.
 /// </summary>
-public unsafe struct OrchardReceiver : IUnifiedPoolReceiver
+public unsafe struct OrchardReceiver : IUnifiedPoolReceiver, IEquatable<OrchardReceiver>
 {
 	private const int DLength = 88 / 8;
 	private const int PkdLength = 256 / 8;
@@ -98,4 +97,18 @@ public unsafe struct OrchardReceiver : IUnifiedPoolReceiver
 
 	/// <inheritdoc/>
 	public int Encode(Span<byte> buffer) => this.Span.CopyToRetLength(buffer);
+
+	/// <inheritdoc/>
+	public bool Equals(OrchardReceiver other) => this.Span.SequenceEqual(other.Span);
+
+	/// <inheritdoc/>
+	public override bool Equals([NotNullWhen(true)] object? obj) => obj is OrchardReceiver other && this.Equals(other);
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		HashCode hashCode = default;
+		hashCode.AddBytes(this.Span);
+		return hashCode.ToHashCode();
+	}
 }

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -200,6 +200,7 @@ Nerdbank.Zcash.OrchardReceiver
 Nerdbank.Zcash.OrchardReceiver.D.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.OrchardReceiver.Encode(System.Span<byte> buffer) -> int
 Nerdbank.Zcash.OrchardReceiver.EncodingLength.get -> int
+Nerdbank.Zcash.OrchardReceiver.Equals(Nerdbank.Zcash.OrchardReceiver other) -> bool
 Nerdbank.Zcash.OrchardReceiver.OrchardReceiver() -> void
 Nerdbank.Zcash.OrchardReceiver.OrchardReceiver(System.ReadOnlySpan<byte> d, System.ReadOnlySpan<byte> pkd) -> void
 Nerdbank.Zcash.OrchardReceiver.Pkd.get -> System.ReadOnlySpan<byte>
@@ -404,6 +405,7 @@ Nerdbank.Zcash.SaplingReceiver
 Nerdbank.Zcash.SaplingReceiver.D.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SaplingReceiver.Encode(System.Span<byte> buffer) -> int
 Nerdbank.Zcash.SaplingReceiver.EncodingLength.get -> int
+Nerdbank.Zcash.SaplingReceiver.Equals(Nerdbank.Zcash.SaplingReceiver other) -> bool
 Nerdbank.Zcash.SaplingReceiver.Pkd.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SaplingReceiver.Pool.get -> Nerdbank.Zcash.Pool
 Nerdbank.Zcash.SaplingReceiver.SaplingReceiver() -> void
@@ -415,6 +417,7 @@ Nerdbank.Zcash.SproutReceiver
 Nerdbank.Zcash.SproutReceiver.Apk.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SproutReceiver.Encode(System.Span<byte> buffer) -> int
 Nerdbank.Zcash.SproutReceiver.EncodingLength.get -> int
+Nerdbank.Zcash.SproutReceiver.Equals(Nerdbank.Zcash.SproutReceiver other) -> bool
 Nerdbank.Zcash.SproutReceiver.PkEnc.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SproutReceiver.Pool.get -> Nerdbank.Zcash.Pool
 Nerdbank.Zcash.SproutReceiver.Span.get -> System.ReadOnlySpan<byte>
@@ -494,6 +497,7 @@ Nerdbank.Zcash.TransparentP2SHAddress.TransparentP2SHAddress(in Nerdbank.Zcash.T
 Nerdbank.Zcash.TransparentP2SHReceiver
 Nerdbank.Zcash.TransparentP2SHReceiver.Encode(System.Span<byte> buffer) -> int
 Nerdbank.Zcash.TransparentP2SHReceiver.EncodingLength.get -> int
+Nerdbank.Zcash.TransparentP2SHReceiver.Equals(Nerdbank.Zcash.TransparentP2SHReceiver other) -> bool
 Nerdbank.Zcash.TransparentP2SHReceiver.Pool.get -> Nerdbank.Zcash.Pool
 Nerdbank.Zcash.TransparentP2SHReceiver.ScriptHash.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.TransparentP2SHReceiver.Span.get -> System.ReadOnlySpan<byte>
@@ -768,6 +772,8 @@ override Nerdbank.Zcash.OrchardAddress.GetPoolReceiver<TPoolReceiver>() -> TPool
 override Nerdbank.Zcash.OrchardAddress.HasShieldedReceiver.get -> bool
 override Nerdbank.Zcash.OrchardAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
 override Nerdbank.Zcash.OrchardAddress.Receivers.get -> System.Collections.Generic.IReadOnlyList<Nerdbank.Zcash.ZcashAddress!>!
+override Nerdbank.Zcash.OrchardReceiver.Equals(object? obj) -> bool
+override Nerdbank.Zcash.OrchardReceiver.GetHashCode() -> int
 override Nerdbank.Zcash.RawTransaction.GetHashCode() -> int
 override Nerdbank.Zcash.RawTransaction.JSDescriptionBCTV14.GetHashCode() -> int
 override Nerdbank.Zcash.RawTransaction.JSDescriptionGroth16.GetHashCode() -> int
@@ -787,12 +793,18 @@ override Nerdbank.Zcash.Sapling.IncomingViewingKey.GetHashCode() -> int
 override Nerdbank.Zcash.SaplingAddress.GetPoolReceiver<TPoolReceiver>() -> TPoolReceiver?
 override Nerdbank.Zcash.SaplingAddress.HasShieldedReceiver.get -> bool
 override Nerdbank.Zcash.SaplingAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
+override Nerdbank.Zcash.SaplingReceiver.Equals(object? obj) -> bool
+override Nerdbank.Zcash.SaplingReceiver.GetHashCode() -> int
 override Nerdbank.Zcash.SproutAddress.GetPoolReceiver<TPoolReceiver>() -> TPoolReceiver?
 override Nerdbank.Zcash.SproutAddress.HasShieldedReceiver.get -> bool
 override Nerdbank.Zcash.SproutAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
+override Nerdbank.Zcash.SproutReceiver.Equals(object? obj) -> bool
+override Nerdbank.Zcash.SproutReceiver.GetHashCode() -> int
 override Nerdbank.Zcash.TexAddress.GetPoolReceiver<TPoolReceiver>() -> TPoolReceiver?
 override Nerdbank.Zcash.TexAddress.HasShieldedReceiver.get -> bool
 override Nerdbank.Zcash.TexAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
+override Nerdbank.Zcash.TexReceiver.Equals(object? obj) -> bool
+override Nerdbank.Zcash.TexReceiver.GetHashCode() -> int
 override Nerdbank.Zcash.Transaction.Equals(object? obj) -> bool
 override Nerdbank.Zcash.Transaction.LineItem.GetHashCode() -> int
 override Nerdbank.Zcash.Transaction.GetHashCode() -> int
@@ -800,9 +812,13 @@ override Nerdbank.Zcash.Transaction.ToString() -> string!
 override Nerdbank.Zcash.TransparentP2PKHAddress.GetPoolReceiver<TPoolReceiver>() -> TPoolReceiver?
 override Nerdbank.Zcash.TransparentP2PKHAddress.HasShieldedReceiver.get -> bool
 override Nerdbank.Zcash.TransparentP2PKHAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
+override Nerdbank.Zcash.TransparentP2PKHReceiver.Equals(object? obj) -> bool
+override Nerdbank.Zcash.TransparentP2PKHReceiver.GetHashCode() -> int
 override Nerdbank.Zcash.TransparentP2SHAddress.GetPoolReceiver<TPoolReceiver>() -> TPoolReceiver?
 override Nerdbank.Zcash.TransparentP2SHAddress.HasShieldedReceiver.get -> bool
 override Nerdbank.Zcash.TransparentP2SHAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
+override Nerdbank.Zcash.TransparentP2SHReceiver.Equals(object? obj) -> bool
+override Nerdbank.Zcash.TransparentP2SHReceiver.GetHashCode() -> int
 override Nerdbank.Zcash.TxId.Equals(object? obj) -> bool
 override Nerdbank.Zcash.TxId.GetHashCode() -> int
 override Nerdbank.Zcash.TxId.ToString() -> string!

--- a/src/Nerdbank.Zcash/SaplingReceiver.cs
+++ b/src/Nerdbank.Zcash/SaplingReceiver.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Nerdbank.Zcash;
@@ -9,7 +8,7 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Sapling"/> pool.
 /// </summary>
-public unsafe struct SaplingReceiver : IUnifiedPoolReceiver
+public unsafe struct SaplingReceiver : IUnifiedPoolReceiver, IEquatable<SaplingReceiver>
 {
 	/// <summary>
 	/// Gets the number of bytes in a sapling receiver.
@@ -101,4 +100,18 @@ public unsafe struct SaplingReceiver : IUnifiedPoolReceiver
 
 	/// <inheritdoc/>
 	public int Encode(Span<byte> buffer) => this.Span.CopyToRetLength(buffer);
+
+	/// <inheritdoc/>
+	public bool Equals(SaplingReceiver other) => this.Span.SequenceEqual(other.Span);
+
+	/// <inheritdoc/>
+	public override bool Equals([NotNullWhen(true)] object? obj) => obj is SaplingReceiver other && this.Equals(other);
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		HashCode hashCode = default;
+		hashCode.AddBytes(this.Span);
+		return hashCode.ToHashCode();
+	}
 }

--- a/src/Nerdbank.Zcash/SproutReceiver.cs
+++ b/src/Nerdbank.Zcash/SproutReceiver.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Nerdbank.Zcash;
@@ -9,7 +8,7 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Sprout"/> pool.
 /// </summary>
-public unsafe struct SproutReceiver : IPoolReceiver
+public unsafe struct SproutReceiver : IPoolReceiver, IEquatable<SproutReceiver>
 {
 	private const int FieldLength = 256 / 8;
 	private const int Length = FieldLength * 2;
@@ -92,4 +91,18 @@ public unsafe struct SproutReceiver : IPoolReceiver
 
 	/// <inheritdoc/>
 	public int Encode(Span<byte> buffer) => this.Span.CopyToRetLength(buffer);
+
+	/// <inheritdoc/>
+	public bool Equals(SproutReceiver other) => this.Span.SequenceEqual(other.Span);
+
+	/// <inheritdoc/>
+	public override bool Equals([NotNullWhen(true)] object? obj) => obj is SproutReceiver other && this.Equals(other);
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		HashCode hashCode = default;
+		hashCode.AddBytes(this.Span);
+		return hashCode.ToHashCode();
+	}
 }

--- a/src/Nerdbank.Zcash/TexReceiver.cs
+++ b/src/Nerdbank.Zcash/TexReceiver.cs
@@ -77,5 +77,16 @@ public unsafe struct TexReceiver : IPoolReceiver, IEquatable<TexReceiver>
 	public int Encode(Span<byte> buffer) => this.Span.CopyToRetLength(buffer);
 
 	/// <inheritdoc/>
-	public bool Equals(TexReceiver other) => this.ValidatingKeyHash.SequenceEqual(other.ValidatingKeyHash);
+	public bool Equals(TexReceiver other) => this.Span.SequenceEqual(other.Span);
+
+	/// <inheritdoc/>
+	public override bool Equals([NotNullWhen(true)] object? obj) => obj is TexReceiver other && this.Equals(other);
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		HashCode hashCode = default;
+		hashCode.AddBytes(this.Span);
+		return hashCode.ToHashCode();
+	}
 }

--- a/src/Nerdbank.Zcash/TransparentP2PKHReceiver.cs
+++ b/src/Nerdbank.Zcash/TransparentP2PKHReceiver.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using Org.BouncyCastle.Crypto.Digests;
 
 namespace Nerdbank.Zcash;
 
@@ -90,5 +87,16 @@ public unsafe struct TransparentP2PKHReceiver : IUnifiedPoolReceiver, IEquatable
 	public int Encode(Span<byte> buffer) => this.Span.CopyToRetLength(buffer);
 
 	/// <inheritdoc/>
-	public bool Equals(TransparentP2PKHReceiver other) => this.ValidatingKeyHash.SequenceEqual(other.ValidatingKeyHash);
+	public bool Equals(TransparentP2PKHReceiver other) => this.Span.SequenceEqual(other.Span);
+
+	/// <inheritdoc/>
+	public override bool Equals([NotNullWhen(true)] object? obj) => obj is TransparentP2PKHReceiver other && this.Equals(other);
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		HashCode hashCode = default;
+		hashCode.AddBytes(this.Span);
+		return hashCode.ToHashCode();
+	}
 }

--- a/src/Nerdbank.Zcash/TransparentP2SHReceiver.cs
+++ b/src/Nerdbank.Zcash/TransparentP2SHReceiver.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Nerdbank.Zcash;
@@ -10,7 +9,7 @@ namespace Nerdbank.Zcash;
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Transparent"/> pool
 /// by way of a Pay to Script Hash method.
 /// </summary>
-public unsafe struct TransparentP2SHReceiver : IUnifiedPoolReceiver
+public unsafe struct TransparentP2SHReceiver : IUnifiedPoolReceiver, IEquatable<TransparentP2SHReceiver>
 {
 	private const int Length = 160 / 8;
 
@@ -63,4 +62,18 @@ public unsafe struct TransparentP2SHReceiver : IUnifiedPoolReceiver
 
 	/// <inheritdoc/>
 	public int Encode(Span<byte> buffer) => this.Span.CopyToRetLength(buffer);
+
+	/// <inheritdoc/>
+	public bool Equals(TransparentP2SHReceiver other) => this.Span.SequenceEqual(other.Span);
+
+	/// <inheritdoc/>
+	public override bool Equals([NotNullWhen(true)] object? obj) => obj is TransparentP2SHReceiver other && this.Equals(other);
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		HashCode hashCode = default;
+		hashCode.AddBytes(this.Span);
+		return hashCode.ToHashCode();
+	}
 }

--- a/src/Nerdbank.Zcash/ZcashAddress.cs
+++ b/src/Nerdbank.Zcash/ZcashAddress.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-
 namespace Nerdbank.Zcash;
 
 /// <summary>
@@ -222,6 +220,7 @@ public abstract class ZcashAddress : IEquatable<ZcashAddress>, IUnifiedEncodingE
 		// This must be manually maintained as new receiver types are added.
 		TestReceiver<TransparentP2PKHReceiver>();
 		TestReceiver<TransparentP2SHReceiver>();
+		TestReceiver<TexReceiver>();
 		TestReceiver<SproutReceiver>();
 		TestReceiver<SaplingReceiver>();
 		TestReceiver<OrchardReceiver>();
@@ -229,7 +228,7 @@ public abstract class ZcashAddress : IEquatable<ZcashAddress>, IUnifiedEncodingE
 		return match;
 
 		void TestReceiver<T>()
-			where T : unmanaged, IPoolReceiver
+			where T : unmanaged, IPoolReceiver, IEquatable<T>
 		{
 			T? thisReceiver = this.GetPoolReceiver<T>();
 			T? candidateReceiver = candidate.GetPoolReceiver<T>();
@@ -244,7 +243,7 @@ public abstract class ZcashAddress : IEquatable<ZcashAddress>, IUnifiedEncodingE
 					match |= Match.UniqueReceiverTypesInReceivingAddress;
 					break;
 				case (not null, not null):
-					if (thisReceiver.Equals(candidateReceiver))
+					if (thisReceiver.Value.Equals(candidateReceiver.Value))
 					{
 						match |= Match.MatchingReceiversFound;
 					}

--- a/test/Nerdbank.Zcash.Tests/OrchardReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/OrchardReceiverTests.cs
@@ -31,4 +31,44 @@ public class OrchardReceiverTests
 
 	[Fact]
 	public void UnifiedReceiverTypeCode() => Assert.Equal(0x03, OrchardReceiver.UnifiedReceiverTypeCode);
+
+	[Fact]
+	public void EqualityOfT()
+	{
+		byte[] d = new byte[11];
+		byte[] pkd = new byte[32];
+
+		d[1] = 2;
+		pkd[2] = 4;
+		OrchardReceiver receiver = new(d.ToArray(), pkd.ToArray());
+		OrchardReceiver receiver_copy = new(d.ToArray(), pkd.ToArray());
+		d[3] = 3;
+		OrchardReceiver receiver_unique = new(d.ToArray(), pkd.ToArray());
+		pkd[5] = 8;
+		OrchardReceiver receiver_unique2 = new(d.ToArray(), pkd.ToArray());
+
+		Assert.Equal(receiver, receiver_copy);
+		Assert.NotEqual(receiver, receiver_unique);
+		Assert.NotEqual(receiver_unique2, receiver_unique);
+	}
+
+	[Fact]
+	public void EqualsObjectOverride()
+	{
+		byte[] d = new byte[11];
+		byte[] pkd = new byte[32];
+
+		d[1] = 2;
+		pkd[2] = 4;
+		OrchardReceiver receiver = new(d.ToArray(), pkd.ToArray());
+		OrchardReceiver receiver_copy = new(d.ToArray(), pkd.ToArray());
+		d[3] = 3;
+		OrchardReceiver receiver_unique = new(d.ToArray(), pkd.ToArray());
+		pkd[5] = 8;
+		OrchardReceiver receiver_unique2 = new(d.ToArray(), pkd.ToArray());
+
+		Assert.True(receiver.Equals((object)receiver_copy));
+		Assert.False(receiver.Equals((object)receiver_unique));
+		Assert.False(receiver_unique2.Equals((object)receiver_unique));
+	}
 }

--- a/test/Nerdbank.Zcash.Tests/SaplingReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/SaplingReceiverTests.cs
@@ -34,4 +34,44 @@ public class SaplingReceiverTests
 	{
 		Assert.Equal(0x02, SaplingReceiver.UnifiedReceiverTypeCode);
 	}
+
+	[Fact]
+	public void EqualityOfT()
+	{
+		byte[] d = new byte[11];
+		byte[] pkd = new byte[32];
+
+		d[1] = 2;
+		pkd[2] = 4;
+		SaplingReceiver receiver = new(d.ToArray(), pkd.ToArray());
+		SaplingReceiver receiver_copy = new(d.ToArray(), pkd.ToArray());
+		d[3] = 3;
+		SaplingReceiver receiver_unique = new(d.ToArray(), pkd.ToArray());
+		pkd[5] = 8;
+		SaplingReceiver receiver_unique2 = new(d.ToArray(), pkd.ToArray());
+
+		Assert.Equal(receiver, receiver_copy);
+		Assert.NotEqual(receiver, receiver_unique);
+		Assert.NotEqual(receiver_unique2, receiver_unique);
+	}
+
+	[Fact]
+	public void EqualsObjectOverride()
+	{
+		byte[] d = new byte[11];
+		byte[] pkd = new byte[32];
+
+		d[1] = 2;
+		pkd[2] = 4;
+		SaplingReceiver receiver = new(d.ToArray(), pkd.ToArray());
+		SaplingReceiver receiver_copy = new(d.ToArray(), pkd.ToArray());
+		d[3] = 3;
+		SaplingReceiver receiver_unique = new(d.ToArray(), pkd.ToArray());
+		pkd[5] = 8;
+		SaplingReceiver receiver_unique2 = new(d.ToArray(), pkd.ToArray());
+
+		Assert.True(receiver.Equals((object)receiver_copy));
+		Assert.False(receiver.Equals((object)receiver_unique));
+		Assert.False(receiver_unique2.Equals((object)receiver_unique));
+	}
 }

--- a/test/Nerdbank.Zcash.Tests/SproutReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/SproutReceiverTests.cs
@@ -27,18 +27,39 @@ public class SproutReceiverTests
 	}
 
 	[Fact]
-	public void Equality()
+	public void EqualityOfT()
 	{
 		byte[] apk = new byte[32];
 		byte[] pkEnc = new byte[32];
 
-		SproutReceiver receiver1a = new(apk, pkEnc);
-		SproutReceiver receiver1b = new(apk, pkEnc);
+		SproutReceiver receiver1a = new(apk.ToArray(), pkEnc.ToArray());
+		SproutReceiver receiver1b = new(apk.ToArray(), pkEnc.ToArray());
 		Assert.Equal(receiver1a, receiver1b);
 
 		apk[0] = 1;
-		SproutReceiver receiver2 = new(apk, pkEnc);
+		SproutReceiver receiver2 = new(apk.ToArray(), pkEnc.ToArray());
+		pkEnc[3] = 8;
+		SproutReceiver receiver3 = new(apk.ToArray(), pkEnc.ToArray());
 		Assert.NotEqual(receiver1a, receiver2);
+		Assert.NotEqual(receiver3, receiver2);
+	}
+
+	[Fact]
+	public void EqualsObjectOverride()
+	{
+		byte[] apk = new byte[32];
+		byte[] pkEnc = new byte[32];
+
+		SproutReceiver receiver1a = new(apk.ToArray(), pkEnc.ToArray());
+		SproutReceiver receiver1b = new(apk.ToArray(), pkEnc.ToArray());
+		Assert.True(receiver1a.Equals((object)receiver1b));
+
+		apk[0] = 1;
+		SproutReceiver receiver2 = new(apk.ToArray(), pkEnc.ToArray());
+		pkEnc[3] = 8;
+		SproutReceiver receiver3 = new(apk.ToArray(), pkEnc.ToArray());
+		Assert.False(receiver1a.Equals((object)receiver2));
+		Assert.False(receiver3.Equals((object)receiver2));
 	}
 
 	[Fact]

--- a/test/Nerdbank.Zcash.Tests/TexReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TexReceiverTests.cs
@@ -44,4 +44,32 @@ public class TexReceiverTests
 		TexReceiver texReceiver = transparentReceiver;
 		Assert.Equal(transparentReceiver.ValidatingKeyHash, texReceiver.ValidatingKeyHash);
 	}
+
+	[Fact]
+	public void EqualityOfT()
+	{
+		byte[] hash = new byte[20];
+		hash[1] = 2;
+		TexReceiver receiver = new(hash.ToArray());
+		TexReceiver receiver_copy = new(hash.ToArray());
+		hash[3] = 3;
+		TexReceiver receiver_unique = new(hash.ToArray());
+
+		Assert.Equal(receiver, receiver_copy);
+		Assert.NotEqual(receiver, receiver_unique);
+	}
+
+	[Fact]
+	public void EqualsObjectOverride()
+	{
+		byte[] hash = new byte[20];
+		hash[1] = 2;
+		TexReceiver receiver = new(hash.ToArray());
+		TexReceiver receiver_copy = new(hash.ToArray());
+		hash[3] = 3;
+		TexReceiver receiver_unique = new(hash.ToArray());
+
+		Assert.True(receiver.Equals((object)receiver_copy));
+		Assert.False(receiver.Equals((object)receiver_unique));
+	}
 }

--- a/test/Nerdbank.Zcash.Tests/TransparentP2PKHReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2PKHReceiverTests.cs
@@ -27,4 +27,32 @@ public class TransparentP2PKHReceiverTests
 
 	[Fact]
 	public void UnifiedReceiverTypeCode() => Assert.Equal(0x02, TransparentP2PKHReceiver.UnifiedReceiverTypeCode);
+
+	[Fact]
+	public void EqualityOfT()
+	{
+		byte[] hash = new byte[20];
+		hash[1] = 2;
+		TransparentP2PKHReceiver receiver = new(hash.ToArray());
+		TransparentP2PKHReceiver receiver_copy = new(hash.ToArray());
+		hash[3] = 3;
+		TransparentP2PKHReceiver receiver_unique = new(hash.ToArray());
+
+		Assert.Equal(receiver, receiver_copy);
+		Assert.NotEqual(receiver, receiver_unique);
+	}
+
+	[Fact]
+	public void EqualsObjectOverride()
+	{
+		byte[] hash = new byte[20];
+		hash[1] = 2;
+		TransparentP2PKHReceiver receiver = new(hash.ToArray());
+		TransparentP2PKHReceiver receiver_copy = new(hash.ToArray());
+		hash[3] = 3;
+		TransparentP2PKHReceiver receiver_unique = new(hash.ToArray());
+
+		Assert.True(receiver.Equals((object)receiver_copy));
+		Assert.False(receiver.Equals((object)receiver_unique));
+	}
 }

--- a/test/Nerdbank.Zcash.Tests/TransparentP2SHReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2SHReceiverTests.cs
@@ -27,4 +27,32 @@ public class TransparentP2SHReceiverTests
 
 	[Fact]
 	public void UnifiedReceiverTypeCode() => Assert.Equal(0x01, TransparentP2SHReceiver.UnifiedReceiverTypeCode);
+
+	[Fact]
+	public void EqualityOfT()
+	{
+		byte[] hash = new byte[20];
+		hash[1] = 2;
+		TransparentP2SHReceiver receiver = new(hash.ToArray());
+		TransparentP2SHReceiver receiver_copy = new(hash.ToArray());
+		hash[3] = 3;
+		TransparentP2SHReceiver receiver_unique = new(hash.ToArray());
+
+		Assert.Equal(receiver, receiver_copy);
+		Assert.NotEqual(receiver, receiver_unique);
+	}
+
+	[Fact]
+	public void EqualsObjectOverride()
+	{
+		byte[] hash = new byte[20];
+		hash[1] = 2;
+		TransparentP2SHReceiver receiver = new(hash.ToArray());
+		TransparentP2SHReceiver receiver_copy = new(hash.ToArray());
+		hash[3] = 3;
+		TransparentP2SHReceiver receiver_unique = new(hash.ToArray());
+
+		Assert.True(receiver.Equals((object)receiver_copy));
+		Assert.False(receiver.Equals((object)receiver_unique));
+	}
 }


### PR DESCRIPTION
This was caused by missing explicit `Equals` methods on the `OrchardReceiver` struct, leading to the default `ValueType.Equals` behavior that is inadequate. I made some other changes to help ensure the fix is and remains complete.

I also added the `TexReceiver` to the `IsMatch` method since it was missing there.