### PR TITLE
Migrate to newer C# inline array support

### DIFF
--- a/src/Nerdbank.Bitcoin/Bip32HDWallet.ChainCode.cs
+++ b/src/Nerdbank.Bitcoin/Bip32HDWallet.ChainCode.cs
@@ -37,7 +37,7 @@ public static partial class Bip32HDWallet
 		public static ref readonly ChainCode From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, ChainCode>(value));
 
 		/// <inheritdoc/>
-		bool IEquatable<ChainCode>.Equals(ChainCode other) => this[..].SequenceEqual(other);
+		readonly bool IEquatable<ChainCode>.Equals(ChainCode other) => this[..].SequenceEqual(other);
 
 		/// <inheritdoc cref="IEquatable{T}.Equals"/>
 		public readonly bool Equals(in ChainCode other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Bitcoin/Bip32HDWallet.ParentFingerprint.cs
+++ b/src/Nerdbank.Bitcoin/Bip32HDWallet.ParentFingerprint.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Nerdbank.Bitcoin;
@@ -38,7 +37,7 @@ public static partial class Bip32HDWallet
 		public static ref readonly ParentFingerprint From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, ParentFingerprint>(value));
 
 		/// <inheritdoc/>
-		bool IEquatable<ParentFingerprint>.Equals(ParentFingerprint other) => this[..].SequenceEqual(other);
+		readonly bool IEquatable<ParentFingerprint>.Equals(ParentFingerprint other) => this[..].SequenceEqual(other);
 
 		/// <inheritdoc cref="IEquatable{T}.Equals"/>
 		public readonly bool Equals(in ParentFingerprint other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Bitcoin/BitcoinP2PKHAddress.cs
+++ b/src/Nerdbank.Bitcoin/BitcoinP2PKHAddress.cs
@@ -145,7 +145,7 @@ public class BitcoinP2PKHAddress
 		public static ref readonly PublicKeyHashArray From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, PublicKeyHashArray>(value));
 
 		/// <inheritdoc/>
-		bool IEquatable<PublicKeyHashArray>.Equals(PublicKeyHashArray other) => this[..].SequenceEqual(other);
+		readonly bool IEquatable<PublicKeyHashArray>.Equals(PublicKeyHashArray other) => this[..].SequenceEqual(other);
 
 		/// <inheritdoc cref="IEquatable{T}.Equals"/>
 		public readonly bool Equals(in PublicKeyHashArray other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Cryptocurrencies/Blake2B.cs
+++ b/src/Nerdbank.Cryptocurrencies/Blake2B.cs
@@ -8,6 +8,7 @@
  * It was later substantially modified by Andrew Arnott as part of the containing project and a new license and copyright applied.
  */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Nerdbank.Cryptocurrencies;
@@ -434,16 +435,22 @@ public class Blake2B
 
 		internal bool IsKeySet { get; set; }
 
+		[UnscopedRef]
 		internal Span<ulong> RawConfig => MemoryMarshal.CreateSpan(ref this.rawConfig[0], 8);
 
+		[UnscopedRef]
 		internal Span<ulong> M => MemoryMarshal.CreateSpan(ref this.m[0], 16);
 
+		[UnscopedRef]
 		internal Span<ulong> H => MemoryMarshal.CreateSpan(ref this.h[0], 8);
 
+		[UnscopedRef]
 		internal Span<ulong> V => MemoryMarshal.CreateSpan(ref this.v[0], 16);
 
+		[UnscopedRef]
 		internal Span<byte> Buf => MemoryMarshal.CreateSpan(ref this.buf[0], 128);
 
+		[UnscopedRef]
 		internal Span<byte> Key => this.IsKeySet ? MemoryMarshal.CreateSpan(ref this.key[0], 128) : default;
 	}
 }

--- a/src/Nerdbank.Zcash/Bytes32.cs
+++ b/src/Nerdbank.Zcash/Bytes32.cs
@@ -35,7 +35,7 @@ internal struct Bytes32 : IEquatable<Bytes32>
 	public static ref readonly Bytes32 From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, Bytes32>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<Bytes32>.Equals(Bytes32 other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<Bytes32>.Equals(Bytes32 other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in Bytes32 other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Bytes96.cs
+++ b/src/Nerdbank.Zcash/Bytes96.cs
@@ -35,7 +35,7 @@ internal struct Bytes96 : IEquatable<Bytes96>
 	public static ref readonly Bytes96 From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, Bytes96>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<Bytes96>.Equals(Bytes96 other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<Bytes96>.Equals(Bytes96 other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in Bytes96 other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/DiversifierIndex.cs
+++ b/src/Nerdbank.Zcash/DiversifierIndex.cs
@@ -83,7 +83,7 @@ public struct DiversifierIndex : IEquatable<DiversifierIndex>
 	public readonly BigInteger ToBigInteger() => new BigInteger(this, isUnsigned: true);
 
 	/// <inheritdoc/>
-	bool IEquatable<DiversifierIndex>.Equals(DiversifierIndex other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<DiversifierIndex>.Equals(DiversifierIndex other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in DiversifierIndex other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/DiversifierKey.cs
+++ b/src/Nerdbank.Zcash/DiversifierKey.cs
@@ -35,7 +35,7 @@ internal struct DiversifierKey : IEquatable<DiversifierKey>
 	public static ref readonly DiversifierKey From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, DiversifierKey>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<DiversifierKey>.Equals(DiversifierKey other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<DiversifierKey>.Equals(DiversifierKey other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in DiversifierKey other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Memo.cs
+++ b/src/Nerdbank.Zcash/Memo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-
 namespace Nerdbank.Zcash;
 
 /// <summary>
@@ -107,8 +105,14 @@ public struct Memo : IEquatable<Memo>
 	}
 
 	[InlineArray(512)]
-	private struct Bytes512
+	private struct Bytes512 : IEquatable<Bytes512>
 	{
 		private byte element0;
+
+		/// <inheritdoc />
+		readonly bool IEquatable<Bytes512>.Equals(Bytes512 other) => this[..].SequenceEqual(other);
+
+		/// <inheritdoc cref="IEquatable{T}.Equals"/>
+		public readonly bool Equals(in Bytes512 other) => this[..].SequenceEqual(other);
 	}
 }

--- a/src/Nerdbank.Zcash/NullifierDerivingKey.cs
+++ b/src/Nerdbank.Zcash/NullifierDerivingKey.cs
@@ -35,7 +35,7 @@ internal struct NullifierDerivingKey : IEquatable<NullifierDerivingKey>
 	public static ref readonly NullifierDerivingKey From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, NullifierDerivingKey>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<NullifierDerivingKey>.Equals(NullifierDerivingKey other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<NullifierDerivingKey>.Equals(NullifierDerivingKey other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in NullifierDerivingKey other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Orchard/CommitIvkRandomness.cs
+++ b/src/Nerdbank.Zcash/Orchard/CommitIvkRandomness.cs
@@ -35,7 +35,7 @@ internal struct CommitIvkRandomness : IEquatable<CommitIvkRandomness>
 	public static ref readonly CommitIvkRandomness From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, CommitIvkRandomness>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<CommitIvkRandomness>.Equals(CommitIvkRandomness other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<CommitIvkRandomness>.Equals(CommitIvkRandomness other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in CommitIvkRandomness other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Orchard/Diversifier.cs
+++ b/src/Nerdbank.Zcash/Orchard/Diversifier.cs
@@ -35,7 +35,7 @@ internal struct Diversifier : IEquatable<Diversifier>
 	public static ref readonly Diversifier From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, Diversifier>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<Diversifier>.Equals(Diversifier other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<Diversifier>.Equals(Diversifier other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in Diversifier other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Orchard/IncomingViewingKey.cs
+++ b/src/Nerdbank.Zcash/Orchard/IncomingViewingKey.cs
@@ -260,7 +260,7 @@ public class IncomingViewingKey : IUnifiedEncodingElement, IIncomingViewingKey, 
 		public static ref readonly RawEncodingBuffer From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, RawEncodingBuffer>(value));
 
 		/// <inheritdoc/>
-		bool IEquatable<RawEncodingBuffer>.Equals(RawEncodingBuffer other) => this[..].SequenceEqual(other);
+		readonly bool IEquatable<RawEncodingBuffer>.Equals(RawEncodingBuffer other) => this[..].SequenceEqual(other);
 
 		/// <inheritdoc cref="IEquatable{T}.Equals"/>
 		public readonly bool Equals(in RawEncodingBuffer other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Orchard/IncomingViewingKey.cs
+++ b/src/Nerdbank.Zcash/Orchard/IncomingViewingKey.cs
@@ -140,7 +140,7 @@ public class IncomingViewingKey : IUnifiedEncodingElement, IIncomingViewingKey, 
 	/// <para>This is a simpler front-end for the <see cref="TryGetDiversifierIndex"/> method,
 	/// which runs a similar test but also provides the decrypted diversifier index.</para>
 	/// </remarks>
-	public bool CheckReceiver(OrchardReceiver receiver) => this.TryGetDiversifierIndex(receiver, out _);
+	public bool CheckReceiver(in OrchardReceiver receiver) => this.TryGetDiversifierIndex(receiver, out _);
 
 	/// <summary>
 	/// Checks whether a given orchard receiver was derived from the same spending authority as this key
@@ -151,12 +151,12 @@ public class IncomingViewingKey : IUnifiedEncodingElement, IIncomingViewingKey, 
 	/// <param name="diversifierIndex">Receives the original diversifier index, if successful.</param>
 	/// <returns>A value indicating whether the receiver could be decrypted successfully (i.e. the receiver came from this key).</returns>
 	/// <remarks>
-	/// <para>Use <see cref="CheckReceiver(OrchardReceiver)"/> for a simpler API if the diversifier index is not required.</para>
+	/// <para>Use <see cref="CheckReceiver(in OrchardReceiver)"/> for a simpler API if the diversifier index is not required.</para>
 	/// </remarks>
-	public bool TryGetDiversifierIndex(OrchardReceiver receiver, [NotNullWhen(true)] out DiversifierIndex? diversifierIndex)
+	public bool TryGetDiversifierIndex(in OrchardReceiver receiver, [NotNullWhen(true)] out DiversifierIndex? diversifierIndex)
 	{
 		Span<byte> diversifierSpan = stackalloc byte[11];
-		switch (NativeMethods.DecryptOrchardDiversifier(this.RawEncoding, receiver.Span, diversifierSpan))
+		switch (NativeMethods.DecryptOrchardDiversifier(this.RawEncoding, receiver, diversifierSpan))
 		{
 			case 0:
 				diversifierIndex = new(diversifierSpan);

--- a/src/Nerdbank.Zcash/Orchard/KeyAgreementPrivateKey.cs
+++ b/src/Nerdbank.Zcash/Orchard/KeyAgreementPrivateKey.cs
@@ -35,7 +35,7 @@ internal struct KeyAgreementPrivateKey : IEquatable<KeyAgreementPrivateKey>
 	public static ref readonly KeyAgreementPrivateKey From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, KeyAgreementPrivateKey>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<KeyAgreementPrivateKey>.Equals(KeyAgreementPrivateKey other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<KeyAgreementPrivateKey>.Equals(KeyAgreementPrivateKey other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in KeyAgreementPrivateKey other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Orchard/SpendValidatingKey.cs
+++ b/src/Nerdbank.Zcash/Orchard/SpendValidatingKey.cs
@@ -35,7 +35,7 @@ internal struct SpendValidatingKey : IEquatable<SpendValidatingKey>
 	public static ref readonly SpendValidatingKey From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, SpendValidatingKey>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<SpendValidatingKey>.Equals(SpendValidatingKey other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<SpendValidatingKey>.Equals(SpendValidatingKey other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in SpendValidatingKey other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/OrchardAddress.cs
+++ b/src/Nerdbank.Zcash/OrchardAddress.cs
@@ -46,7 +46,7 @@ public class OrchardAddress : UnifiedAddress
 	public override IReadOnlyList<ZcashAddress> Receivers => this.receivers ??= new ReadOnlyCollection<ZcashAddress>(new[] { this });
 
 	/// <inheritdoc/>
-	internal override byte UnifiedTypeCode => UnifiedTypeCodes.Orchard;
+	internal override byte UnifiedTypeCode => OrchardReceiver.UnifiedReceiverTypeCode;
 
 	/// <inheritdoc/>
 	internal override int ReceiverEncodingLength => OrchardReceiver.Length;

--- a/src/Nerdbank.Zcash/OrchardAddress.cs
+++ b/src/Nerdbank.Zcash/OrchardAddress.cs
@@ -49,7 +49,7 @@ public class OrchardAddress : UnifiedAddress
 	internal override byte UnifiedTypeCode => UnifiedTypeCodes.Orchard;
 
 	/// <inheritdoc/>
-	internal override int ReceiverEncodingLength => this.receiver.Span.Length;
+	internal override int ReceiverEncodingLength => OrchardReceiver.Length;
 
 	/// <inheritdoc/>
 	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<OrchardReceiver, TPoolReceiver>(this.receiver);

--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -4,6 +4,12 @@ abstract Nerdbank.Zcash.ZcashAddress.HasShieldedReceiver.get -> bool
 abstract Nerdbank.Zcash.ZcashAddress.Network.get -> Nerdbank.Zcash.ZcashNetwork
 const Nerdbank.Zcash.DiversifierIndex.Length = 11 -> int
 const Nerdbank.Zcash.LightWalletClient.MinimumConfirmations = 3 -> int
+const Nerdbank.Zcash.OrchardReceiver.Length = 43 -> int
+const Nerdbank.Zcash.SaplingReceiver.Length = 43 -> int
+const Nerdbank.Zcash.SproutReceiver.Length = 64 -> int
+const Nerdbank.Zcash.TexReceiver.Length = 20 -> int
+const Nerdbank.Zcash.TransparentP2PKHReceiver.Length = 20 -> int
+const Nerdbank.Zcash.TransparentP2SHReceiver.Length = 20 -> int
 const Nerdbank.Zcash.TxId.Length = 32 -> int
 const Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyFingerprint.Length = 32 -> int
 const Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag.Length = 4 -> int
@@ -181,14 +187,14 @@ Nerdbank.Zcash.Orchard.FullViewingKey.IncomingViewingKey.get -> Nerdbank.Zcash.O
 Nerdbank.Zcash.Orchard.FullViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.Orchard.FullViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Orchard.IncomingViewingKey
-Nerdbank.Zcash.Orchard.IncomingViewingKey.CheckReceiver(Nerdbank.Zcash.OrchardReceiver receiver) -> bool
+Nerdbank.Zcash.Orchard.IncomingViewingKey.CheckReceiver(in Nerdbank.Zcash.OrchardReceiver receiver) -> bool
 Nerdbank.Zcash.Orchard.IncomingViewingKey.CreateDefaultReceiver() -> Nerdbank.Zcash.OrchardReceiver
 Nerdbank.Zcash.Orchard.IncomingViewingKey.CreateReceiver(Nerdbank.Zcash.DiversifierIndex diversifierIndex) -> Nerdbank.Zcash.OrchardReceiver
 Nerdbank.Zcash.Orchard.IncomingViewingKey.DefaultAddress.get -> Nerdbank.Zcash.OrchardAddress!
 Nerdbank.Zcash.Orchard.IncomingViewingKey.Equals(Nerdbank.Zcash.Orchard.IncomingViewingKey? other) -> bool
 Nerdbank.Zcash.Orchard.IncomingViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.Orchard.IncomingViewingKey.TextEncoding.get -> string!
-Nerdbank.Zcash.Orchard.IncomingViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.OrchardReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
+Nerdbank.Zcash.Orchard.IncomingViewingKey.TryGetDiversifierIndex(in Nerdbank.Zcash.OrchardReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
 Nerdbank.Zcash.Orchard.SpendingKey
 Nerdbank.Zcash.Orchard.SpendingKey.FullViewingKey.get -> Nerdbank.Zcash.Orchard.FullViewingKey!
 Nerdbank.Zcash.Orchard.SpendingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Orchard.IncomingViewingKey!
@@ -199,13 +205,11 @@ Nerdbank.Zcash.OrchardAddress.OrchardAddress(in Nerdbank.Zcash.OrchardReceiver r
 Nerdbank.Zcash.OrchardReceiver
 Nerdbank.Zcash.OrchardReceiver.D.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.OrchardReceiver.Encode(System.Span<byte> buffer) -> int
-Nerdbank.Zcash.OrchardReceiver.EncodingLength.get -> int
-Nerdbank.Zcash.OrchardReceiver.Equals(Nerdbank.Zcash.OrchardReceiver other) -> bool
+Nerdbank.Zcash.OrchardReceiver.Equals(in Nerdbank.Zcash.OrchardReceiver other) -> bool
 Nerdbank.Zcash.OrchardReceiver.OrchardReceiver() -> void
 Nerdbank.Zcash.OrchardReceiver.OrchardReceiver(System.ReadOnlySpan<byte> d, System.ReadOnlySpan<byte> pkd) -> void
 Nerdbank.Zcash.OrchardReceiver.Pkd.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.OrchardReceiver.Pool.get -> Nerdbank.Zcash.Pool
-Nerdbank.Zcash.OrchardReceiver.Span.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.ParseError
 Nerdbank.Zcash.ParseError.InvalidAddress = 1 -> Nerdbank.Zcash.ParseError
 Nerdbank.Zcash.ParseError.InvalidParam = 4 -> Nerdbank.Zcash.ParseError
@@ -371,20 +375,20 @@ Nerdbank.Zcash.RawTransaction.Version.get -> uint
 Nerdbank.Zcash.RawTransaction.VersionGroupId.get -> uint
 Nerdbank.Zcash.RawTransaction.VersionGroupId.init -> void
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey
-Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.CheckReceiver(Nerdbank.Zcash.SaplingReceiver receiver) -> bool
+Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.CheckReceiver(in Nerdbank.Zcash.SaplingReceiver receiver) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.DeriveInternal() -> Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey!
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.Equals(Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey? other) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.IncomingViewingKey.get -> Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey!
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.TextEncoding.get -> string!
-Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
+Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.TryGetDiversifierIndex(in Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableFullViewingKey.WithoutDiversifierKey.get -> Nerdbank.Zcash.Sapling.FullViewingKey!
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey
-Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.CheckReceiver(Nerdbank.Zcash.SaplingReceiver receiver) -> bool
+Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.CheckReceiver(in Nerdbank.Zcash.SaplingReceiver receiver) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.CreateDefaultReceiver() -> Nerdbank.Zcash.SaplingReceiver
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.DefaultAddress.get -> Nerdbank.Zcash.SaplingAddress!
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TextEncoding.get -> string!
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryCreateReceiver(ref Nerdbank.Zcash.DiversifierIndex diversifierIndex, out Nerdbank.Zcash.SaplingReceiver? receiver) -> bool
-Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryGetDiversifierIndex(Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
+Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.TryGetDiversifierIndex(in Nerdbank.Zcash.SaplingReceiver receiver, out Nerdbank.Zcash.DiversifierIndex? diversifierIndex) -> bool
 Nerdbank.Zcash.Sapling.DiversifiableIncomingViewingKey.WithoutDiversifierKey.get -> Nerdbank.Zcash.Sapling.IncomingViewingKey!
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey
 Nerdbank.Zcash.Sapling.ExpandedSpendingKey.Equals(Nerdbank.Zcash.Sapling.ExpandedSpendingKey? other) -> bool
@@ -404,23 +408,19 @@ Nerdbank.Zcash.SaplingAddress.SaplingAddress(in Nerdbank.Zcash.SaplingReceiver r
 Nerdbank.Zcash.SaplingReceiver
 Nerdbank.Zcash.SaplingReceiver.D.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SaplingReceiver.Encode(System.Span<byte> buffer) -> int
-Nerdbank.Zcash.SaplingReceiver.EncodingLength.get -> int
-Nerdbank.Zcash.SaplingReceiver.Equals(Nerdbank.Zcash.SaplingReceiver other) -> bool
+Nerdbank.Zcash.SaplingReceiver.Equals(in Nerdbank.Zcash.SaplingReceiver other) -> bool
 Nerdbank.Zcash.SaplingReceiver.Pkd.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SaplingReceiver.Pool.get -> Nerdbank.Zcash.Pool
 Nerdbank.Zcash.SaplingReceiver.SaplingReceiver() -> void
 Nerdbank.Zcash.SaplingReceiver.SaplingReceiver(System.ReadOnlySpan<byte> d, System.ReadOnlySpan<byte> pkd) -> void
-Nerdbank.Zcash.SaplingReceiver.Span.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SproutAddress
 Nerdbank.Zcash.SproutAddress.SproutAddress(in Nerdbank.Zcash.SproutReceiver receiver, Nerdbank.Zcash.ZcashNetwork network = Nerdbank.Zcash.ZcashNetwork.MainNet) -> void
 Nerdbank.Zcash.SproutReceiver
 Nerdbank.Zcash.SproutReceiver.Apk.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SproutReceiver.Encode(System.Span<byte> buffer) -> int
-Nerdbank.Zcash.SproutReceiver.EncodingLength.get -> int
-Nerdbank.Zcash.SproutReceiver.Equals(Nerdbank.Zcash.SproutReceiver other) -> bool
+Nerdbank.Zcash.SproutReceiver.Equals(in Nerdbank.Zcash.SproutReceiver other) -> bool
 Nerdbank.Zcash.SproutReceiver.PkEnc.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SproutReceiver.Pool.get -> Nerdbank.Zcash.Pool
-Nerdbank.Zcash.SproutReceiver.Span.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.SproutReceiver.SproutReceiver() -> void
 Nerdbank.Zcash.SproutReceiver.SproutReceiver(System.ReadOnlySpan<byte> apk, System.ReadOnlySpan<byte> pkEnc) -> void
 Nerdbank.Zcash.TexAddress
@@ -428,15 +428,12 @@ Nerdbank.Zcash.TexAddress.TexAddress(in Nerdbank.Zcash.TexReceiver receiver, Ner
 Nerdbank.Zcash.TexAddress.TexAddress(Nerdbank.Zcash.TransparentP2PKHAddress! transparentAddress) -> void
 Nerdbank.Zcash.TexReceiver
 Nerdbank.Zcash.TexReceiver.Encode(System.Span<byte> buffer) -> int
-Nerdbank.Zcash.TexReceiver.EncodingLength.get -> int
-Nerdbank.Zcash.TexReceiver.Equals(Nerdbank.Zcash.TexReceiver other) -> bool
+Nerdbank.Zcash.TexReceiver.Equals(in Nerdbank.Zcash.TexReceiver other) -> bool
 Nerdbank.Zcash.TexReceiver.Pool.get -> Nerdbank.Zcash.Pool
-Nerdbank.Zcash.TexReceiver.Span.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.TexReceiver.TexReceiver() -> void
 Nerdbank.Zcash.TexReceiver.TexReceiver(Nerdbank.Zcash.Transparent.PublicKey! publicKey) -> void
 Nerdbank.Zcash.TexReceiver.TexReceiver(Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey! publicKey) -> void
 Nerdbank.Zcash.TexReceiver.TexReceiver(System.ReadOnlySpan<byte> p2pkh) -> void
-Nerdbank.Zcash.TexReceiver.ValidatingKeyHash.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.Transaction
 Nerdbank.Zcash.Transaction.Change.get -> System.Collections.Immutable.ImmutableArray<Nerdbank.Zcash.Transaction.LineItem>
 Nerdbank.Zcash.Transaction.ExpiredUnmined.get -> bool
@@ -483,24 +480,18 @@ Nerdbank.Zcash.TransparentP2PKHAddress
 Nerdbank.Zcash.TransparentP2PKHAddress.TransparentP2PKHAddress(in Nerdbank.Zcash.TransparentP2PKHReceiver receiver, Nerdbank.Zcash.ZcashNetwork network = Nerdbank.Zcash.ZcashNetwork.MainNet) -> void
 Nerdbank.Zcash.TransparentP2PKHReceiver
 Nerdbank.Zcash.TransparentP2PKHReceiver.Encode(System.Span<byte> buffer) -> int
-Nerdbank.Zcash.TransparentP2PKHReceiver.EncodingLength.get -> int
-Nerdbank.Zcash.TransparentP2PKHReceiver.Equals(Nerdbank.Zcash.TransparentP2PKHReceiver other) -> bool
+Nerdbank.Zcash.TransparentP2PKHReceiver.Equals(in Nerdbank.Zcash.TransparentP2PKHReceiver other) -> bool
 Nerdbank.Zcash.TransparentP2PKHReceiver.Pool.get -> Nerdbank.Zcash.Pool
-Nerdbank.Zcash.TransparentP2PKHReceiver.Span.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.TransparentP2PKHReceiver.TransparentP2PKHReceiver() -> void
 Nerdbank.Zcash.TransparentP2PKHReceiver.TransparentP2PKHReceiver(Nerdbank.Zcash.Transparent.PublicKey! publicKey) -> void
 Nerdbank.Zcash.TransparentP2PKHReceiver.TransparentP2PKHReceiver(Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey! publicKey) -> void
 Nerdbank.Zcash.TransparentP2PKHReceiver.TransparentP2PKHReceiver(System.ReadOnlySpan<byte> p2pkh) -> void
-Nerdbank.Zcash.TransparentP2PKHReceiver.ValidatingKeyHash.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.TransparentP2SHAddress
 Nerdbank.Zcash.TransparentP2SHAddress.TransparentP2SHAddress(in Nerdbank.Zcash.TransparentP2SHReceiver receiver, Nerdbank.Zcash.ZcashNetwork network = Nerdbank.Zcash.ZcashNetwork.MainNet) -> void
 Nerdbank.Zcash.TransparentP2SHReceiver
 Nerdbank.Zcash.TransparentP2SHReceiver.Encode(System.Span<byte> buffer) -> int
-Nerdbank.Zcash.TransparentP2SHReceiver.EncodingLength.get -> int
-Nerdbank.Zcash.TransparentP2SHReceiver.Equals(Nerdbank.Zcash.TransparentP2SHReceiver other) -> bool
+Nerdbank.Zcash.TransparentP2SHReceiver.Equals(in Nerdbank.Zcash.TransparentP2SHReceiver other) -> bool
 Nerdbank.Zcash.TransparentP2SHReceiver.Pool.get -> Nerdbank.Zcash.Pool
-Nerdbank.Zcash.TransparentP2SHReceiver.ScriptHash.get -> System.ReadOnlySpan<byte>
-Nerdbank.Zcash.TransparentP2SHReceiver.Span.get -> System.ReadOnlySpan<byte>
 Nerdbank.Zcash.TransparentP2SHReceiver.TransparentP2SHReceiver() -> void
 Nerdbank.Zcash.TransparentP2SHReceiver.TransparentP2SHReceiver(System.ReadOnlySpan<byte> p2sh) -> void
 Nerdbank.Zcash.TxId
@@ -731,8 +722,8 @@ Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey.Network.get -> Nerd
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedSpendingKey.ParentFullViewingKeyTag.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.ChainCode.get -> Nerdbank.Bitcoin.Bip32HDWallet.ChainCode
-Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.CheckReceiver(Nerdbank.Zcash.TransparentP2PKHReceiver receiver, uint maxAddressIndex) -> bool
-Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.CheckReceiver(Nerdbank.Zcash.TransparentP2SHReceiver receiver, uint maxAddressIndex) -> bool
+Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.CheckReceiver(in Nerdbank.Zcash.TransparentP2PKHReceiver receiver, uint maxAddressIndex) -> bool
+Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.CheckReceiver(in Nerdbank.Zcash.TransparentP2SHReceiver receiver, uint maxAddressIndex) -> bool
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.DefaultAddress.get -> Nerdbank.Zcash.TransparentAddress!
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.Equals(Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey? other) -> bool
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.ExtendedViewingKey(Nerdbank.Bitcoin.Bip32HDWallet.ExtendedPublicKey! copyFrom, Nerdbank.Zcash.ZcashNetwork network) -> void
@@ -743,8 +734,8 @@ Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.IsFullViewingKey.get
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.Key.get -> Nerdbank.Zcash.Transparent.PublicKey!
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.Network.get -> Nerdbank.Zcash.ZcashNetwork
 Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.ParentFullViewingKeyTag.get -> Nerdbank.Zcash.Zip32HDWallet.FullViewingKeyTag
-Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.TryGetAddressIndex(Nerdbank.Zcash.TransparentP2PKHReceiver receiver, uint maxAddressIndex, out Nerdbank.Bitcoin.Bip44MultiAccountHD.Change? change, out uint? addressIndex) -> bool
-Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.TryGetAddressIndex(Nerdbank.Zcash.TransparentP2SHReceiver receiver, uint maxAddressIndex, out Nerdbank.Bitcoin.Bip44MultiAccountHD.Change? change, out uint? addressIndex) -> bool
+Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.TryGetAddressIndex(in Nerdbank.Zcash.TransparentP2PKHReceiver receiver, uint maxAddressIndex, out Nerdbank.Bitcoin.Bip44MultiAccountHD.Change? change, out uint? addressIndex) -> bool
+Nerdbank.Zcash.Zip32HDWallet.Transparent.ExtendedViewingKey.TryGetAddressIndex(in Nerdbank.Zcash.TransparentP2SHReceiver receiver, uint maxAddressIndex, out Nerdbank.Bitcoin.Bip44MultiAccountHD.Change? change, out uint? addressIndex) -> bool
 Nerdbank.Zcash.Zip32HDWallet.Zip32HDWallet(Nerdbank.Bitcoin.Bip39Mnemonic! mnemonic, Nerdbank.Zcash.ZcashNetwork network = Nerdbank.Zcash.ZcashNetwork.MainNet) -> void
 Nerdbank.Zcash.Zip32HDWallet.Zip32HDWallet(System.ReadOnlySpan<byte> seed, Nerdbank.Zcash.ZcashNetwork network) -> void
 override Nerdbank.Zcash.AccountBalances.Equals(object? obj) -> bool

--- a/src/Nerdbank.Zcash/Sapling/DiversifiableFullViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/DiversifiableFullViewingKey.cs
@@ -108,7 +108,7 @@ public class DiversifiableFullViewingKey : FullViewingKey, IFullViewingKey, IUni
 	/// <para>This is a simpler front-end for the <see cref="TryGetDiversifierIndex"/> method,
 	/// which runs a similar test but also provides the decrypted diversifier index.</para>
 	/// </remarks>
-	public bool CheckReceiver(SaplingReceiver receiver) => this.TryGetDiversifierIndex(receiver, out _);
+	public bool CheckReceiver(in SaplingReceiver receiver) => this.TryGetDiversifierIndex(receiver, out _);
 
 	/// <summary>
 	/// Checks whether a given sapling receiver was derived from the same spending authority as this key
@@ -119,13 +119,13 @@ public class DiversifiableFullViewingKey : FullViewingKey, IFullViewingKey, IUni
 	/// <param name="diversifierIndex">Receives the original diversifier index, if successful.</param>
 	/// <returns>A value indicating whether the receiver could be decrypted successfully (i.e. the receiver came from this key).</returns>
 	/// <remarks>
-	/// <para>Use <see cref="CheckReceiver(SaplingReceiver)"/> for a simpler API if the diversifier index is not required.</para>
+	/// <para>Use <see cref="CheckReceiver(in SaplingReceiver)"/> for a simpler API if the diversifier index is not required.</para>
 	/// </remarks>
-	public bool TryGetDiversifierIndex(SaplingReceiver receiver, [NotNullWhen(true)] out DiversifierIndex? diversifierIndex)
+	public bool TryGetDiversifierIndex(in SaplingReceiver receiver, [NotNullWhen(true)] out DiversifierIndex? diversifierIndex)
 	{
 		Bytes96 rawEncoding = this.ToBytes();
 		Span<byte> diversifierSpan = stackalloc byte[11];
-		switch (NativeMethods.DecryptSaplingDiversifier(rawEncoding, this.Dk, receiver.Span, diversifierSpan, out _))
+		switch (NativeMethods.DecryptSaplingDiversifier(rawEncoding, this.Dk, receiver, diversifierSpan, out _))
 		{
 			case 0:
 				diversifierIndex = DiversifierIndex.From(diversifierSpan);

--- a/src/Nerdbank.Zcash/Sapling/DiversifiableIncomingViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/DiversifiableIncomingViewingKey.cs
@@ -147,7 +147,7 @@ public class DiversifiableIncomingViewingKey : IncomingViewingKey, IUnifiedEncod
 	/// <para>This is a simpler front-end for the <see cref="TryGetDiversifierIndex"/> method,
 	/// which runs a similar test but also provides the decrypted diversifier index.</para>
 	/// </remarks>
-	public bool CheckReceiver(SaplingReceiver receiver) => this.TryGetDiversifierIndex(receiver, out _);
+	public bool CheckReceiver(in SaplingReceiver receiver) => this.TryGetDiversifierIndex(receiver, out _);
 
 	/// <summary>
 	/// Checks whether a given sapling receiver was derived from the same spending authority as this key
@@ -158,12 +158,12 @@ public class DiversifiableIncomingViewingKey : IncomingViewingKey, IUnifiedEncod
 	/// <param name="diversifierIndex">Receives the original diversifier index, if successful.</param>
 	/// <returns>A value indicating whether the receiver could be decrypted successfully (i.e. the receiver came from this key).</returns>
 	/// <remarks>
-	/// <para>Use <see cref="CheckReceiver(SaplingReceiver)"/> for a simpler API if the diversifier index is not required.</para>
+	/// <para>Use <see cref="CheckReceiver(in SaplingReceiver)"/> for a simpler API if the diversifier index is not required.</para>
 	/// </remarks>
-	public bool TryGetDiversifierIndex(SaplingReceiver receiver, [NotNullWhen(true)] out DiversifierIndex? diversifierIndex)
+	public bool TryGetDiversifierIndex(in SaplingReceiver receiver, [NotNullWhen(true)] out DiversifierIndex? diversifierIndex)
 	{
 		Span<byte> diversifierSpan = stackalloc byte[11];
-		switch (NativeMethods.DecryptSaplingDiversifierWithIvk(this.Ivk, this.Dk, receiver.Span, diversifierSpan))
+		switch (NativeMethods.DecryptSaplingDiversifierWithIvk(this.Ivk, this.Dk, receiver, diversifierSpan))
 		{
 			case 0:
 				diversifierIndex = new(diversifierSpan);

--- a/src/Nerdbank.Zcash/Sapling/OutgoingViewingKey.cs
+++ b/src/Nerdbank.Zcash/Sapling/OutgoingViewingKey.cs
@@ -35,7 +35,7 @@ internal struct OutgoingViewingKey : IEquatable<OutgoingViewingKey>
 	public static ref readonly OutgoingViewingKey From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, OutgoingViewingKey>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<OutgoingViewingKey>.Equals(OutgoingViewingKey other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<OutgoingViewingKey>.Equals(OutgoingViewingKey other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in OutgoingViewingKey other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Sapling/SubgroupPoint.cs
+++ b/src/Nerdbank.Zcash/Sapling/SubgroupPoint.cs
@@ -35,7 +35,7 @@ internal struct SubgroupPoint : IEquatable<SubgroupPoint>
 	public static ref readonly SubgroupPoint From(ReadOnlySpan<byte> value) => ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, SubgroupPoint>(value));
 
 	/// <inheritdoc/>
-	bool IEquatable<SubgroupPoint>.Equals(SubgroupPoint other) => this[..].SequenceEqual(other);
+	readonly bool IEquatable<SubgroupPoint>.Equals(SubgroupPoint other) => this[..].SequenceEqual(other);
 
 	/// <inheritdoc cref="IEquatable{T}.Equals"/>
 	public readonly bool Equals(in SubgroupPoint other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/SaplingAddress.cs
+++ b/src/Nerdbank.Zcash/SaplingAddress.cs
@@ -44,7 +44,7 @@ public class SaplingAddress : ZcashAddress
 	public override bool HasShieldedReceiver => true;
 
 	/// <inheritdoc/>
-	internal override byte UnifiedTypeCode => UnifiedTypeCodes.Sapling;
+	internal override byte UnifiedTypeCode => SaplingReceiver.UnifiedReceiverTypeCode;
 
 	/// <inheritdoc/>
 	internal override int ReceiverEncodingLength => SaplingReceiver.Length;

--- a/src/Nerdbank.Zcash/SaplingAddress.cs
+++ b/src/Nerdbank.Zcash/SaplingAddress.cs
@@ -47,7 +47,7 @@ public class SaplingAddress : ZcashAddress
 	internal override byte UnifiedTypeCode => UnifiedTypeCodes.Sapling;
 
 	/// <inheritdoc/>
-	internal override int ReceiverEncodingLength => this.receiver.EncodingLength;
+	internal override int ReceiverEncodingLength => SaplingReceiver.Length;
 
 	/// <inheritdoc/>
 	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<SaplingReceiver, TPoolReceiver>(this.receiver);
@@ -100,9 +100,8 @@ public class SaplingAddress : ZcashAddress
 			ZcashNetwork.TestNet => TestNetHumanReadablePart,
 			_ => throw new NotSupportedException(Strings.FormatUnrecognizedNetwork(network)),
 		};
-		ReadOnlySpan<byte> receiverSpan = receiver.Span;
-		Span<char> addressChars = stackalloc char[Bech32.GetEncodedLength(humanReadablePart.Length, receiverSpan.Length)];
-		int charsLength = Bech32.Original.Encode(humanReadablePart, receiverSpan, addressChars);
+		Span<char> addressChars = stackalloc char[Bech32.GetEncodedLength(humanReadablePart.Length, SaplingReceiver.Length)];
+		int charsLength = Bech32.Original.Encode(humanReadablePart, receiver, addressChars);
 		return addressChars[..charsLength].ToString();
 	}
 }

--- a/src/Nerdbank.Zcash/SaplingReceiver.cs
+++ b/src/Nerdbank.Zcash/SaplingReceiver.cs
@@ -1,22 +1,22 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.InteropServices;
-
 namespace Nerdbank.Zcash;
 
 /// <summary>
 /// A receiver that contains the cryptography parameters required to send Zcash to the <see cref="Pool.Sapling"/> pool.
 /// </summary>
-public unsafe struct SaplingReceiver : IUnifiedPoolReceiver, IEquatable<SaplingReceiver>
+[InlineArray(Length)]
+public struct SaplingReceiver : IUnifiedPoolReceiver, IEquatable<SaplingReceiver>
 {
 	/// <summary>
-	/// Gets the number of bytes in a sapling receiver.
+	/// Gets the length of the receiver, in bytes.
 	/// </summary>
-	internal const int Length = 11 + 32;
+	public const int Length = 11 + 32;
+
 	private const int DLength = 11;
 	private const int PkdLength = 32;
-	private fixed byte backing[Length];
+	private byte backing;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="SaplingReceiver"/> struct.
@@ -36,8 +36,8 @@ public unsafe struct SaplingReceiver : IUnifiedPoolReceiver, IEquatable<SaplingR
 			throw new ArgumentException($"Length must be exactly {PkdLength}, but was {pkd.Length}.", nameof(pkd));
 		}
 
-		d.CopyTo(this.DWritable);
-		pkd.CopyTo(this.PkdWritable);
+		d.CopyTo(this[..DLength]);
+		pkd.CopyTo(this[DLength..]);
 	}
 
 	/// <summary>
@@ -52,7 +52,7 @@ public unsafe struct SaplingReceiver : IUnifiedPoolReceiver, IEquatable<SaplingR
 			throw new ArgumentException($"Length must be exactly {Length}, but was {receiver.Length}.", nameof(receiver));
 		}
 
-		receiver.CopyTo(this.SpanWritable);
+		receiver.CopyTo(this);
 	}
 
 	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
@@ -65,53 +65,34 @@ public unsafe struct SaplingReceiver : IUnifiedPoolReceiver, IEquatable<SaplingR
 	/// Gets the LEBS2OSP(d) on the receiver.
 	/// </summary>
 	[UnscopedRef]
-	public readonly ReadOnlySpan<byte> D => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in this.backing[0]), DLength);
+	public readonly ReadOnlySpan<byte> D => this[..DLength];
 
 	/// <summary>
 	/// Gets the LEBS2OSP(repr(pkd)) on the receiver.
 	/// </summary>
 	[UnscopedRef]
-	public readonly ReadOnlySpan<byte> Pkd => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in this.backing[DLength]), PkdLength);
+	public readonly ReadOnlySpan<byte> Pkd => this[DLength..];
 
 	/// <inheritdoc />
-	public readonly int EncodingLength => Length;
-
-	/// <summary>
-	/// Gets the encoded representation of the entire receiver.
-	/// </summary>
-	[UnscopedRef]
-	public readonly ReadOnlySpan<byte> Span => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in this.backing[0]), Length);
-
-	/// <inheritdoc cref="Span" />
-	[UnscopedRef]
-	private Span<byte> SpanWritable => MemoryMarshal.CreateSpan(ref this.backing[0], Length);
-
-	/// <summary>
-	/// Gets the LEBS2OSP(d) on the receiver.
-	/// </summary>
-	[UnscopedRef]
-	private Span<byte> DWritable => MemoryMarshal.CreateSpan(ref this.backing[0], DLength);
-
-	/// <summary>
-	/// Gets the LEBS2OSP(repr(pkd)) on the receiver.
-	/// </summary>
-	[UnscopedRef]
-	private Span<byte> PkdWritable => MemoryMarshal.CreateSpan(ref this.backing[DLength], PkdLength);
+	readonly int IPoolReceiver.EncodingLength => Length;
 
 	/// <inheritdoc/>
-	public int Encode(Span<byte> buffer) => this.Span.CopyToRetLength(buffer);
+	public readonly int Encode(Span<byte> buffer) => this[..].CopyToRetLength(buffer);
 
 	/// <inheritdoc/>
-	public bool Equals(SaplingReceiver other) => this.Span.SequenceEqual(other.Span);
+	readonly bool IEquatable<SaplingReceiver>.Equals(SaplingReceiver other) => this.Equals(other);
+
+	/// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+	public readonly bool Equals(in SaplingReceiver other) => this[..].SequenceEqual(other[..]);
 
 	/// <inheritdoc/>
-	public override bool Equals([NotNullWhen(true)] object? obj) => obj is SaplingReceiver other && this.Equals(other);
+	public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is SaplingReceiver other && this.Equals(other);
 
 	/// <inheritdoc/>
-	public override int GetHashCode()
+	public override readonly int GetHashCode()
 	{
 		HashCode hashCode = default;
-		hashCode.AddBytes(this.Span);
+		hashCode.AddBytes(this);
 		return hashCode.ToHashCode();
 	}
 }

--- a/src/Nerdbank.Zcash/SproutAddress.cs
+++ b/src/Nerdbank.Zcash/SproutAddress.cs
@@ -42,7 +42,7 @@ public class SproutAddress : ZcashAddress
 	public override bool HasShieldedReceiver => true;
 
 	/// <inheritdoc/>
-	internal override byte UnifiedTypeCode => throw new NotSupportedException();
+	internal override byte UnifiedTypeCode => throw new NotSupportedException(Strings.AddressDoesNotSupportUnifiedEncoding);
 
 	/// <inheritdoc/>
 	[ExcludeFromCodeCoverage]

--- a/src/Nerdbank.Zcash/SproutAddress.cs
+++ b/src/Nerdbank.Zcash/SproutAddress.cs
@@ -98,7 +98,7 @@ public class SproutAddress : ZcashAddress
 
 	private static string CreateAddress(in SproutReceiver receiver, ZcashNetwork network)
 	{
-		Span<byte> input = stackalloc byte[2 + receiver.EncodingLength];
+		Span<byte> input = stackalloc byte[2 + SproutReceiver.Length];
 		(input[0], input[1]) = network switch
 		{
 			ZcashNetwork.MainNet => ((byte)0x16, (byte)0x9a),

--- a/src/Nerdbank.Zcash/TexAddress.cs
+++ b/src/Nerdbank.Zcash/TexAddress.cs
@@ -62,7 +62,7 @@ public class TexAddress : TransparentAddress
 	internal override byte UnifiedTypeCode => throw new NotSupportedException(Strings.AddressDoesNotSupportUnifiedEncoding);
 
 	/// <inheritdoc/>
-	internal override int ReceiverEncodingLength => this.receiver.EncodingLength;
+	internal override int ReceiverEncodingLength => TexReceiver.Length;
 
 	/// <inheritdoc/>
 	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<TexReceiver, TPoolReceiver>(this.receiver);
@@ -128,8 +128,8 @@ public class TexAddress : TransparentAddress
 			ZcashNetwork.TestNet => HumanReadablePart.TestNet,
 			_ => throw new NotSupportedException(Strings.FormatUnrecognizedNetwork(network)),
 		};
-		Span<char> addressChars = stackalloc char[Bech32.GetEncodedLength(hrp.Length, receiver.ValidatingKeyHash.Length)];
-		int charsLength = Bech32.Bech32m.Encode(hrp, receiver.ValidatingKeyHash, addressChars);
+		Span<char> addressChars = stackalloc char[Bech32.GetEncodedLength(hrp.Length, TexReceiver.Length)];
+		int charsLength = Bech32.Bech32m.Encode(hrp, receiver, addressChars);
 		return addressChars[..charsLength].ToString();
 	}
 

--- a/src/Nerdbank.Zcash/Transparent/PublicKey.cs
+++ b/src/Nerdbank.Zcash/Transparent/PublicKey.cs
@@ -69,9 +69,15 @@ public class PublicKey : IZcashKey, IFullViewingKey
 	public IIncomingViewingKey IncomingViewingKey => this;
 
 	[InlineArray(Length)]
-	private struct PublicKeyMaterial
+	private struct PublicKeyMaterial : IEquatable<PublicKeyMaterial>
 	{
 		public const int Length = 33;
 		private byte element;
+
+		/// <inheritdoc />
+		readonly bool IEquatable<PublicKeyMaterial>.Equals(PublicKeyMaterial other) => this[..].SequenceEqual(other);
+
+		/// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+		public readonly bool Equals(in PublicKeyMaterial other) => this[..].SequenceEqual(other);
 	}
 }

--- a/src/Nerdbank.Zcash/TransparentP2PKHAddress.cs
+++ b/src/Nerdbank.Zcash/TransparentP2PKHAddress.cs
@@ -42,7 +42,7 @@ public class TransparentP2PKHAddress : TransparentAddress
 	public override bool HasShieldedReceiver => false;
 
 	/// <inheritdoc/>
-	internal override byte UnifiedTypeCode => UnifiedTypeCodes.TransparentP2PKH;
+	internal override byte UnifiedTypeCode => TransparentP2PKHReceiver.UnifiedReceiverTypeCode;
 
 	/// <inheritdoc/>
 	internal override int ReceiverEncodingLength => TransparentP2PKHReceiver.Length;

--- a/src/Nerdbank.Zcash/TransparentP2PKHAddress.cs
+++ b/src/Nerdbank.Zcash/TransparentP2PKHAddress.cs
@@ -45,7 +45,7 @@ public class TransparentP2PKHAddress : TransparentAddress
 	internal override byte UnifiedTypeCode => UnifiedTypeCodes.TransparentP2PKH;
 
 	/// <inheritdoc/>
-	internal override int ReceiverEncodingLength => this.receiver.EncodingLength;
+	internal override int ReceiverEncodingLength => TransparentP2PKHReceiver.Length;
 
 	/// <inheritdoc/>
 	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<TransparentP2PKHReceiver, TPoolReceiver>(this.receiver);
@@ -55,14 +55,14 @@ public class TransparentP2PKHAddress : TransparentAddress
 
 	private static string CreateAddress(in TransparentP2PKHReceiver receiver, ZcashNetwork network)
 	{
-		Span<byte> input = stackalloc byte[2 + receiver.ValidatingKeyHash.Length];
+		Span<byte> input = stackalloc byte[2 + TransparentP2PKHReceiver.Length];
 		(input[0], input[1]) = network switch
 		{
 			ZcashNetwork.MainNet => ((byte)0x1c, (byte)0xb8),
 			ZcashNetwork.TestNet => ((byte)0x1d, (byte)0x25),
 			_ => throw new NotSupportedException(Strings.FormatUnrecognizedNetwork(network)),
 		};
-		receiver.ValidatingKeyHash.CopyTo(input[2..]);
+		receiver[..].CopyTo(input[2..]);
 		Span<char> addressChars = stackalloc char[Base58Check.GetMaxEncodedLength(input.Length)];
 		int charsLength = Base58Check.Encode(input, addressChars);
 		return addressChars[..charsLength].ToString();

--- a/src/Nerdbank.Zcash/TransparentP2PKHReceiver.cs
+++ b/src/Nerdbank.Zcash/TransparentP2PKHReceiver.cs
@@ -59,7 +59,7 @@ public struct TransparentP2PKHReceiver : IUnifiedPoolReceiver, IEquatable<Transp
 	}
 
 	/// <inheritdoc cref="IUnifiedPoolReceiver.UnifiedReceiverTypeCode"/>
-	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.Sapling;
+	public static byte UnifiedReceiverTypeCode => UnifiedTypeCodes.TransparentP2PKH;
 
 	/// <inheritdoc/>
 	public readonly Pool Pool => Pool.Transparent;

--- a/src/Nerdbank.Zcash/TransparentP2SHAddress.cs
+++ b/src/Nerdbank.Zcash/TransparentP2SHAddress.cs
@@ -45,7 +45,7 @@ public class TransparentP2SHAddress : TransparentAddress
 	internal override byte UnifiedTypeCode => UnifiedTypeCodes.TransparentP2SH;
 
 	/// <inheritdoc/>
-	internal override int ReceiverEncodingLength => this.receiver.EncodingLength;
+	internal override int ReceiverEncodingLength => TransparentP2SHReceiver.Length;
 
 	/// <inheritdoc/>
 	public override TPoolReceiver? GetPoolReceiver<TPoolReceiver>() => AsReceiver<TransparentP2SHReceiver, TPoolReceiver>(this.receiver);
@@ -55,14 +55,14 @@ public class TransparentP2SHAddress : TransparentAddress
 
 	private static string CreateAddress(in TransparentP2SHReceiver receiver, ZcashNetwork network)
 	{
-		Span<byte> input = stackalloc byte[2 + receiver.ScriptHash.Length];
+		Span<byte> input = stackalloc byte[2 + TransparentP2SHReceiver.Length];
 		(input[0], input[1]) = network switch
 		{
 			ZcashNetwork.MainNet => ((byte)0x1c, (byte)0xbd),
 			ZcashNetwork.TestNet => ((byte)0x1c, (byte)0xba),
 			_ => throw new NotSupportedException(Strings.FormatUnrecognizedNetwork(network)),
 		};
-		receiver.ScriptHash.CopyTo(input[2..]);
+		receiver[..].CopyTo(input[2..]);
 		Span<char> addressChars = stackalloc char[Base58Check.GetMaxEncodedLength(input.Length)];
 		int charsLength = Base58Check.Encode(input, addressChars);
 		return addressChars[..charsLength].ToString();

--- a/src/Nerdbank.Zcash/TransparentP2SHAddress.cs
+++ b/src/Nerdbank.Zcash/TransparentP2SHAddress.cs
@@ -42,7 +42,7 @@ public class TransparentP2SHAddress : TransparentAddress
 	public override bool HasShieldedReceiver => false;
 
 	/// <inheritdoc/>
-	internal override byte UnifiedTypeCode => UnifiedTypeCodes.TransparentP2SH;
+	internal override byte UnifiedTypeCode => TransparentP2SHReceiver.UnifiedReceiverTypeCode;
 
 	/// <inheritdoc/>
 	internal override int ReceiverEncodingLength => TransparentP2SHReceiver.Length;

--- a/src/Nerdbank.Zcash/Zip32HDWallet.FullViewingKeyFingerprint.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.FullViewingKeyFingerprint.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using static Nerdbank.Bitcoin.Bip32HDWallet;
-
 namespace Nerdbank.Zcash;
 
 public partial class Zip32HDWallet
@@ -36,7 +34,7 @@ public partial class Zip32HDWallet
 		public ref readonly FullViewingKeyTag Tag => ref FullViewingKeyTag.From(this[..4]);
 
 		/// <inheritdoc/>
-		bool IEquatable<FullViewingKeyFingerprint>.Equals(FullViewingKeyFingerprint other) => this[..].SequenceEqual(other);
+		readonly bool IEquatable<FullViewingKeyFingerprint>.Equals(FullViewingKeyFingerprint other) => this[..].SequenceEqual(other);
 
 		/// <inheritdoc cref="IEquatable{T}.Equals"/>
 		public readonly bool Equals(in FullViewingKeyFingerprint other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Zip32HDWallet.FullViewingKeyTag.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.FullViewingKeyTag.cs
@@ -51,7 +51,7 @@ public partial class Zip32HDWallet
 		public static ref readonly FullViewingKeyTag From(in ParentFingerprint value) => ref From(value[..]);
 
 		/// <inheritdoc/>
-		bool IEquatable<FullViewingKeyTag>.Equals(FullViewingKeyTag other) => this[..].SequenceEqual(other);
+		readonly bool IEquatable<FullViewingKeyTag>.Equals(FullViewingKeyTag other) => this[..].SequenceEqual(other);
 
 		/// <inheritdoc cref="IEquatable{T}.Equals"/>
 		public readonly bool Equals(in FullViewingKeyTag other) => this[..].SequenceEqual(other);

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Transparent.ExtendedViewingKey.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Transparent.ExtendedViewingKey.cs
@@ -182,13 +182,13 @@ public partial class Zip32HDWallet
 			/// (in other words: would ZEC sent to this receiver arrive in this account?).
 			/// </summary>
 			/// <param name="receiver">The receiver to test.</param>
-			/// <param name="maxAddressIndex"><inheritdoc cref="TryGetAddressIndex(TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)" path="/param[@name='maxAddressIndex']"/></param>
+			/// <param name="maxAddressIndex"><inheritdoc cref="TryGetAddressIndex(in TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)" path="/param[@name='maxAddressIndex']"/></param>
 			/// <returns><see langword="true"/> if this receiver would send ZEC to this account; otherwise <see langword="false"/>.</returns>
 			/// <remarks>
-			/// <para>This is a simpler front-end for the <see cref="TryGetAddressIndex(TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)"/> method,
+			/// <para>This is a simpler front-end for the <see cref="TryGetAddressIndex(in TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)"/> method,
 			/// which runs a similar test but also provides the change and address index derivations that match the given receiver.</para>
 			/// </remarks>
-			public bool CheckReceiver(TransparentP2PKHReceiver receiver, uint maxAddressIndex) => this.TryGetAddressIndex(receiver, maxAddressIndex, out _, out _);
+			public bool CheckReceiver(in TransparentP2PKHReceiver receiver, uint maxAddressIndex) => this.TryGetAddressIndex(receiver, maxAddressIndex, out _, out _);
 
 			/// <summary>
 			/// Checks whether a given transparent receiver was derived from this key
@@ -203,8 +203,9 @@ public partial class Zip32HDWallet
 			/// <param name="change">Receives the chain index (external or change) where a match was found.</param>
 			/// <param name="addressIndex">Receives the address index where a match was found.</param>
 			/// <returns><see langword="true"/> if this receiver would send ZEC to this account; otherwise <see langword="false"/>.</returns>
-			public bool TryGetAddressIndex(TransparentP2PKHReceiver receiver, uint maxAddressIndex, [NotNullWhen(true)] out Bip44MultiAccountHD.Change? change, [NotNullWhen(true)] out uint? addressIndex)
+			public bool TryGetAddressIndex(in TransparentP2PKHReceiver receiver, uint maxAddressIndex, [NotNullWhen(true)] out Bip44MultiAccountHD.Change? change, [NotNullWhen(true)] out uint? addressIndex)
 			{
+				TransparentP2PKHReceiver receiverCopy = receiver;
 				if (this.Depth == 4)
 				{
 					return TestChain(this, out change, out addressIndex);
@@ -219,7 +220,7 @@ public partial class Zip32HDWallet
 					for (uint i = 0; i <= maxAddressIndex; i++)
 					{
 						ExtendedViewingKey candidate = chainKey.Derive(i);
-						if (receiver.Equals(new TransparentP2PKHReceiver(chainKey.Derive(i))))
+						if (receiverCopy.Equals(new TransparentP2PKHReceiver(chainKey.Derive(i))))
 						{
 							change = (Bip44MultiAccountHD.Change)chainKey.ChildIndex;
 							addressIndex = i;
@@ -238,16 +239,16 @@ public partial class Zip32HDWallet
 			/// (in other words: would ZEC sent to this receiver arrive in this account?).
 			/// </summary>
 			/// <param name="receiver">The receiver to test.</param>
-			/// <param name="maxAddressIndex"><inheritdoc cref="TryGetAddressIndex(TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)" path="/param[@name='maxAddressIndex']"/></param>
+			/// <param name="maxAddressIndex"><inheritdoc cref="TryGetAddressIndex(in TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)" path="/param[@name='maxAddressIndex']"/></param>
 			/// <returns><see langword="true"/> if this receiver would send ZEC to this account; otherwise <see langword="false"/>.</returns>
 			/// <remarks>
-			/// <para>This is a simpler front-end for the <see cref="TryGetAddressIndex(TransparentP2SHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)"/> method,
+			/// <para>This is a simpler front-end for the <see cref="TryGetAddressIndex(in TransparentP2SHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)"/> method,
 			/// which runs a similar test but also provides the change and address index derivations that match the given receiver.</para>
 			/// </remarks>
-			public bool CheckReceiver(TransparentP2SHReceiver receiver, uint maxAddressIndex) => this.TryGetAddressIndex(receiver, maxAddressIndex, out _, out _);
+			public bool CheckReceiver(in TransparentP2SHReceiver receiver, uint maxAddressIndex) => this.TryGetAddressIndex(receiver, maxAddressIndex, out _, out _);
 
-			/// <inheritdoc cref="TryGetAddressIndex(TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)"/>
-			public bool TryGetAddressIndex(TransparentP2SHReceiver receiver, uint maxAddressIndex, [NotNullWhen(true)] out Bip44MultiAccountHD.Change? change, [NotNullWhen(true)] out uint? addressIndex)
+			/// <inheritdoc cref="TryGetAddressIndex(in TransparentP2PKHReceiver, uint, out Bip44MultiAccountHD.Change?, out uint?)"/>
+			public bool TryGetAddressIndex(in TransparentP2SHReceiver receiver, uint maxAddressIndex, [NotNullWhen(true)] out Bip44MultiAccountHD.Change? change, [NotNullWhen(true)] out uint? addressIndex)
 			{
 				throw new NotImplementedException();
 			}

--- a/test/Nerdbank.Zcash.Tests/SaplingReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/SaplingReceiverTests.cs
@@ -30,10 +30,7 @@ public class SaplingReceiverTests
 	public void Pool_Sapling() => Assert.Equal(Pool.Sapling, default(SaplingReceiver).Pool);
 
 	[Fact]
-	public void UnifiedReceiverTypeCode()
-	{
-		Assert.Equal(0x02, SaplingReceiver.UnifiedReceiverTypeCode);
-	}
+	public void UnifiedReceiverTypeCode() => Assert.Equal(0x02, SaplingReceiver.UnifiedReceiverTypeCode);
 
 	[Fact]
 	public void EqualityOfT()

--- a/test/Nerdbank.Zcash.Tests/TestBase.cs
+++ b/test/Nerdbank.Zcash.Tests/TestBase.cs
@@ -26,9 +26,9 @@ public abstract class TestBase
 	protected const string ValidTransparentP2SHAddress = "t3JZcvsuaXE6ygokL4XUiZSTrQBUoPYFnXJ";
 	protected const string ValidTexAddress = "tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte";
 
-	protected static readonly Uri LightWalletServerMainNet = new("https://mainnet.lightwalletd.com:9067/");
+	protected static readonly Uri LightWalletServerMainNet = new("https://zcash.mysideoftheweb.com:9067/");
 
-	protected static readonly Uri LightWalletServerTestNet = new("https://lightwalletd.testnet.electriccoin.co:9067/");
+	protected static readonly Uri LightWalletServerTestNet = new("https://zcash.mysideoftheweb.com:19067/");
 
 	protected static readonly Bip39Mnemonic Mnemonic = Bip39Mnemonic.Parse("weapon solid program critic you long skill foot damp kingdom west history car crunch park increase excite hidden bless spot matter razor memory garbage");
 

--- a/test/Nerdbank.Zcash.Tests/TexAddressTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TexAddressTests.cs
@@ -15,8 +15,8 @@ public class TexAddressTests
 	{
 		var tex = (TexAddress)ZcashAddress.Decode("tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte");
 		var tAddr = (TransparentP2PKHAddress)ZcashAddress.Decode("t1VmmGiyjVNeCjxDZzg7vZmd99WyzVby9yC");
-		Assert.Equal(
-			tAddr.GetPoolReceiver<TransparentP2PKHReceiver>()!.Value.ValidatingKeyHash,
-			tex.GetPoolReceiver<TexReceiver>()!.Value.ValidatingKeyHash);
+		TransparentP2PKHReceiver tReceiver = tAddr.GetPoolReceiver<TransparentP2PKHReceiver>()!.Value;
+		TexReceiver texReceiver = tex.GetPoolReceiver<TexReceiver>()!.Value;
+		Assert.Equal(tReceiver[..], texReceiver[..]);
 	}
 }

--- a/test/Nerdbank.Zcash.Tests/TexReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TexReceiverTests.cs
@@ -9,11 +9,11 @@ public class TexReceiverTests
 		byte[] hash = new byte[20];
 		hash[1] = 2;
 		TexReceiver receiver = new(hash);
-		Assert.Equal(hash, receiver.ValidatingKeyHash.ToArray());
+		Assert.Equal(hash, receiver[..]);
 
 		// Verify that a copy of the data has been made.
 		hash[0] = 3;
-		Assert.Equal(0, receiver.ValidatingKeyHash[0]);
+		Assert.Equal(0, receiver[0]);
 	}
 
 	[Fact]
@@ -32,7 +32,7 @@ public class TexReceiverTests
 		Random.Shared.NextBytes(p2pkh);
 		TexReceiver texReceiver = new(p2pkh);
 		TransparentP2PKHReceiver transparentReceiver = (TransparentP2PKHReceiver)texReceiver;
-		Assert.Equal(texReceiver.ValidatingKeyHash, transparentReceiver.ValidatingKeyHash);
+		Assert.Equal(texReceiver[..], transparentReceiver[..]);
 	}
 
 	[Fact]
@@ -42,7 +42,7 @@ public class TexReceiverTests
 		Random.Shared.NextBytes(p2pkh);
 		TransparentP2PKHReceiver transparentReceiver = new(p2pkh);
 		TexReceiver texReceiver = transparentReceiver;
-		Assert.Equal(transparentReceiver.ValidatingKeyHash, texReceiver.ValidatingKeyHash);
+		Assert.Equal(transparentReceiver[..], texReceiver[..]);
 	}
 
 	[Fact]

--- a/test/Nerdbank.Zcash.Tests/TransparentP2PKHReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2PKHReceiverTests.cs
@@ -26,7 +26,7 @@ public class TransparentP2PKHReceiverTests
 	public void Pool_Transparent() => Assert.Equal(Pool.Transparent, default(TransparentP2PKHReceiver).Pool);
 
 	[Fact]
-	public void UnifiedReceiverTypeCode() => Assert.Equal(0x02, TransparentP2PKHReceiver.UnifiedReceiverTypeCode);
+	public void UnifiedReceiverTypeCode() => Assert.Equal(0x00, TransparentP2PKHReceiver.UnifiedReceiverTypeCode);
 
 	[Fact]
 	public void EqualityOfT()

--- a/test/Nerdbank.Zcash.Tests/TransparentP2PKHReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2PKHReceiverTests.cs
@@ -9,11 +9,11 @@ public class TransparentP2PKHReceiverTests
 		byte[] hash = new byte[20];
 		hash[1] = 2;
 		TransparentP2PKHReceiver receiver = new(hash);
-		Assert.Equal(hash, receiver.ValidatingKeyHash.ToArray());
+		Assert.Equal(hash, receiver[..]);
 
 		// Verify that a copy of the data has been made.
 		hash[0] = 3;
-		Assert.Equal(0, receiver.ValidatingKeyHash[0]);
+		Assert.Equal(0, receiver[0]);
 	}
 
 	[Fact]

--- a/test/Nerdbank.Zcash.Tests/TransparentP2SHReceiverTests.cs
+++ b/test/Nerdbank.Zcash.Tests/TransparentP2SHReceiverTests.cs
@@ -9,11 +9,11 @@ public class TransparentP2SHReceiverTests
 		byte[] hash = new byte[20];
 		hash[1] = 2;
 		TransparentP2SHReceiver receiver = new(hash);
-		Assert.Equal(hash, receiver.ScriptHash.ToArray());
+		Assert.Equal(hash, receiver[..].ToArray());
 
 		// Verify that a copy of the data has been made.
 		hash[0] = 3;
-		Assert.Equal(0, receiver.ScriptHash[0]);
+		Assert.Equal(0, receiver[0]);
 	}
 
 	[Fact]


### PR DESCRIPTION
Also:
- Use `readonly` and `in` modifier in more places to reduce large struct copying.
- Fix `TransparentP2PKHReceiver.UnifiedReceiverTypeCode`
- Add missing `[UnscopedRef]` attributes.
- Fix C# network-connected unit tests.
- Add by-value equality to more inline array structs.
- Convert a bunch of `unsafe` `fixed` array structs to use `[InlineArray]`