### PR TITLE
Calculate accurate `from_account_id` column for deshielding transactions

### DIFF
--- a/src/nerdbank-zcash-rust/src/sql_statements.rs
+++ b/src/nerdbank-zcash-rust/src/sql_statements.rs
@@ -11,7 +11,23 @@ pub(crate) const GET_TRANSACTIONS_SQL: &str = r#"
 		t.block_time,
 		t.expired_unmined,
 		txo.output_pool,
-		txo.from_account_id,
+		coalesce(
+			txo.from_account_id,
+			(SELECT account_id
+			 FROM sapling_received_notes srn
+			 WHERE srn.id = (
+			 	SELECT sapling_received_note_id
+			 	FROM sapling_received_note_spends srns
+			 	WHERE transaction_id = tx.id_tx
+			 )),
+			(SELECT account_id 
+			 FROM orchard_received_notes srn 
+			 WHERE srn.id = (
+			 	SELECT orchard_received_note_id
+			 	FROM orchard_received_note_spends srns
+			 	WHERE transaction_id = tx.id_tx
+			 ))
+		) AS from_account_id,
 		txo.to_account_id,
 		txo.to_address,
 		coalesce(s.diversifier, o.diversifier) AS diversifier,

--- a/src/nerdbank-zcash-rust/src/sync.rs
+++ b/src/nerdbank-zcash-rust/src/sync.rs
@@ -1029,9 +1029,12 @@ pub(crate) fn get_transactions(
                 },
             };
 
-            // We establish change by whether the memo does not contain user text,
-            // and that the recipient is to the same account.
+            // We establish change by all the following criteria holding true:
+            // * the recipient is to the same account
+            // * the recipient is shielded (since change will never be sent to the transparent pool).
+            // * the memo does not contain user text,
             let is_change = to_account_id == from_account_id
+                && output_pool > 1
                 && Memo::from_bytes(&memo).is_ok_and(|m| !matches!(m, Memo::Text(_)));
 
             if is_change {


### PR DESCRIPTION
This works around [librustzcash bug 1305](https://github.com/zcash/librustzcash/issues/1305#issuecomment-2159741064).

Also slight improvement to change detection.