### PR TITLE
Fix Unified Spending Key encoding

### DIFF
--- a/src/Nerdbank.Zcash/Orchard/SpendingKey.cs
+++ b/src/Nerdbank.Zcash/Orchard/SpendingKey.cs
@@ -91,7 +91,7 @@ public class SpendingKey : ISpendingKey, IUnifiedEncodingElement
 	/// <param name="keyContribution">The data that would have been written by <see cref="IUnifiedEncodingElement.WriteUnifiedData(Span{byte})"/>.</param>
 	/// <param name="network">The network the key should be used with.</param>
 	/// <returns>The deserialized key.</returns>
-	internal static IUnifiedEncodingElement DecodeUnifiedViewingKeyContribution(ReadOnlySpan<byte> keyContribution, ZcashNetwork network) => new SpendingKey(keyContribution, network);
+	internal static IUnifiedEncodingElement DecodeUnifiedKeyContribution(ReadOnlySpan<byte> keyContribution, ZcashNetwork network) => new SpendingKey(keyContribution, network);
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="FullViewingKey"/> class.

--- a/src/Nerdbank.Zcash/UnifiedSpendingKey.cs
+++ b/src/Nerdbank.Zcash/UnifiedSpendingKey.cs
@@ -139,9 +139,9 @@ internal class UnifiedSpendingKey : IEnumerable<ISpendingKey>, ISpendingKey
 
 			IUnifiedEncodingElement? element = typeCode switch
 			{
-				UnifiedTypeCodes.Orchard => Orchard.SpendingKey.DecodeUnifiedViewingKeyContribution(elementContent, network),
+				UnifiedTypeCodes.Orchard => Orchard.SpendingKey.DecodeUnifiedKeyContribution(elementContent, network),
 				UnifiedTypeCodes.Sapling => Zip32HDWallet.Sapling.ExtendedSpendingKey.DecodeUnifiedViewingKeyContribution(elementContent, network),
-				UnifiedTypeCodes.TransparentP2PKH => Zip32HDWallet.Transparent.ExtendedSpendingKey.DecodeUnifiedViewingKeyContribution(elementContent, network),
+				UnifiedTypeCodes.TransparentP2PKH => Zip32HDWallet.Transparent.ExtendedSpendingKey.DecodeUnifiedKeyContribution(elementContent, network),
 				_ => null,
 			};
 

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.ExtendedSpendingKey.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Sapling.ExtendedSpendingKey.cs
@@ -254,7 +254,7 @@ public partial class Zip32HDWallet
 			/// <inheritdoc/>
 			int IUnifiedEncodingElement.WriteUnifiedData(Span<byte> destination) => this.Encode(destination);
 
-			/// <inheritdoc cref="Zcash.Orchard.SpendingKey.DecodeUnifiedViewingKeyContribution(ReadOnlySpan{byte}, ZcashNetwork)"/>
+			/// <inheritdoc cref="Zcash.Orchard.SpendingKey.DecodeUnifiedKeyContribution(ReadOnlySpan{byte}, ZcashNetwork)"/>
 			internal static IUnifiedEncodingElement DecodeUnifiedViewingKeyContribution(ReadOnlySpan<byte> keyContribution, ZcashNetwork network) => Decode(keyContribution, network);
 
 			private static ExtendedSpendingKey Decode(ReadOnlySpan<byte> encoded, ZcashNetwork network)

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Transparent.ExtendedSpendingKey.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Transparent.ExtendedSpendingKey.cs
@@ -17,6 +17,8 @@ public partial class Zip32HDWallet
 		[DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
 		public class ExtendedSpendingKey : Bip32HDWallet.ExtendedPrivateKey, IExtendedKey, ISpendingKey, IUnifiedEncodingElement, IEquatable<ExtendedSpendingKey>, IKeyWithTextEncoding
 		{
+			private const int ExpectedUnifiedDataLength = 74;
+
 			/// <summary>
 			/// Initializes a new instance of the <see cref="ExtendedSpendingKey"/> class
 			/// that represents a derived key.
@@ -76,7 +78,7 @@ public partial class Zip32HDWallet
 			byte IUnifiedEncodingElement.UnifiedTypeCode => UnifiedTypeCodes.TransparentP2PKH;
 
 			/// <inheritdoc/>
-			int IUnifiedEncodingElement.UnifiedDataLength => 64;
+			int IUnifiedEncodingElement.UnifiedDataLength => ExpectedUnifiedDataLength;
 
 			private new string DebuggerDisplay => $"{this.DefaultAddress} ({this.DerivationPath})";
 
@@ -147,32 +149,33 @@ public partial class Zip32HDWallet
 			/// <inheritdoc/>
 			int IUnifiedEncodingElement.WriteUnifiedData(Span<byte> destination)
 			{
-				int written = 0;
-				this.CryptographicKey.WriteToSpan(destination);
-				written += 32;
+				Span<byte> scratch = stackalloc byte[78];
 
-				written += this.ChainCode[..].CopyToRetLength(destination[written..]);
-				Assumes.True(written == 64);
+				// This is standard BIP32 serialization, except without the Version header.
+				int written = this.WriteBytes(destination);
+				destination[4..].CopyTo(destination);
+				written -= 4;
+
 				return written;
 			}
 
 			/// <inheritdoc cref="Zcash.Orchard.SpendingKey.DecodeUnifiedKeyContribution(ReadOnlySpan{byte}, ZcashNetwork)"/>
 			internal static IUnifiedEncodingElement DecodeUnifiedKeyContribution(ReadOnlySpan<byte> keyContribution, ZcashNetwork network)
 			{
-				Requires.Argument(keyContribution.Length == 64, nameof(keyContribution), "Length expected to be 64.");
-				ReadOnlySpan<byte> publicKeyData = keyContribution[..32];
-				ReadOnlySpan<byte> chainCode = keyContribution[32..64];
+				Requires.Argument(keyContribution.Length == ExpectedUnifiedDataLength, nameof(keyContribution), $"Length expected to be {ExpectedUnifiedDataLength}.");
 
-				// We have to assume or bluff on some of these values, since they aren't preserved by the encoding.
-				// The values don't actually matter as they don't impact the generated cryptographic key.
-				FullViewingKeyTag parentFingerprintTag = default; // we don't know it, but that's OK.
-				byte depth = 3; // A full viewing key always has a depth of 3.
-				uint childIndex = 0; // We don't know it, but that's OK.
+				const int PublicKeyLength = 33;
+
+				byte depth = keyContribution[0];
+				ref readonly ParentFingerprint parentFingerprint = ref ParentFingerprint.From(keyContribution[1..5]);
+				uint childIndex = BitUtilities.ReadUInt32BE(keyContribution[5..9]);
+				ref readonly ChainCode chainCode = ref ChainCode.From(keyContribution.Slice(9, ChainCode.Length));
+				ReadOnlySpan<byte> keyMaterial = keyContribution[^PublicKeyLength..];
 
 				return new ExtendedSpendingKey(
-					ECPrivKey.Create(publicKeyData),
+					ECPrivKey.Create(keyMaterial),
 					new ChainCode(chainCode),
-					parentFingerprintTag,
+					FullViewingKeyTag.From(parentFingerprint),
 					depth,
 					childIndex,
 					network);

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Transparent.ExtendedSpendingKey.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Transparent.ExtendedSpendingKey.cs
@@ -156,8 +156,8 @@ public partial class Zip32HDWallet
 				return written;
 			}
 
-			/// <inheritdoc cref="Zcash.Orchard.SpendingKey.DecodeUnifiedViewingKeyContribution(ReadOnlySpan{byte}, ZcashNetwork)"/>
-			internal static IUnifiedEncodingElement DecodeUnifiedViewingKeyContribution(ReadOnlySpan<byte> keyContribution, ZcashNetwork network)
+			/// <inheritdoc cref="Zcash.Orchard.SpendingKey.DecodeUnifiedKeyContribution(ReadOnlySpan{byte}, ZcashNetwork)"/>
+			internal static IUnifiedEncodingElement DecodeUnifiedKeyContribution(ReadOnlySpan<byte> keyContribution, ZcashNetwork network)
 			{
 				Requires.Argument(keyContribution.Length == 64, nameof(keyContribution), "Length expected to be 64.");
 				ReadOnlySpan<byte> publicKeyData = keyContribution[..32];

--- a/src/Nerdbank.Zcash/Zip32HDWallet.Transparent.ExtendedViewingKey.cs
+++ b/src/Nerdbank.Zcash/Zip32HDWallet.Transparent.ExtendedViewingKey.cs
@@ -307,7 +307,7 @@ public partial class Zip32HDWallet
 				return written;
 			}
 
-			/// <inheritdoc cref="Zcash.Orchard.SpendingKey.DecodeUnifiedViewingKeyContribution(ReadOnlySpan{byte}, ZcashNetwork)"/>
+			/// <inheritdoc cref="Zcash.Orchard.SpendingKey.DecodeUnifiedKeyContribution(ReadOnlySpan{byte}, ZcashNetwork)"/>
 			internal static IUnifiedEncodingElement DecodeUnifiedViewingKeyContribution(ReadOnlySpan<byte> keyContribution, ZcashNetwork network, bool isFullViewingKey)
 			{
 				ReadOnlySpan<byte> chainCode = keyContribution[..32];


### PR DESCRIPTION
Update Unified Spending Key encoding to match librustzcash

librustzcash [changed their USK encoding](https://github.com/zcash/librustzcash/pull/1421) recently.