### PR TITLE
Fix rust tests

### DIFF
--- a/src/nerdbank-zcash-rust/src/sync.rs
+++ b/src/nerdbank-zcash-rust/src/sync.rs
@@ -1098,7 +1098,12 @@ mod tests {
             account_id,
             setup
                 .db
-                .add_account(&seed, zip32::AccountId::ZERO, birthday, &mut setup.client)
+                .add_account(
+                    &seed,
+                    zip32::AccountId::ZERO.next().unwrap(),
+                    birthday,
+                    &mut setup.client,
+                )
                 .await
                 .unwrap()
                 .0


### PR DESCRIPTION
This fixes one test that always fails, that we missed because we ignore cargo test failures in Azure Pipelines.