### PR TITLE
Share gRPC channels again

### DIFF
--- a/src/nerdbank-zcash-rust/Cargo.lock
+++ b/src/nerdbank-zcash-rust/Cargo.lock
@@ -1318,6 +1318,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tokio-shared-rt",
  "tokio-util",
  "tonic",
  "tracing",
@@ -2387,6 +2388,28 @@ dependencies = [
  "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
+]
+
+[[package]]
+name = "tokio-shared-rt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a6bb03ec682a0bb16ce93d19301abc5b98a0d7936477175a156a213dcc47d85"
+dependencies = [
+ "once_cell",
+ "tokio",
+ "tokio-shared-rt-macro",
+]
+
+[[package]]
+name = "tokio-shared-rt-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe49a94e3a984b0d0ab97343dc3dcd52baae1ee13f005bfad39faea47d051dc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/nerdbank-zcash-rust/Cargo.toml
+++ b/src/nerdbank-zcash-rust/Cargo.toml
@@ -72,6 +72,7 @@ zcash_proofs = { path = "../../external/librustzcash/zcash_proofs", features = [
 ], default-features = false }
 zeroize = "1.7.0"
 zip32 = "0.1.1"
+tokio-shared-rt = "0.1.0"
 
 [dev-dependencies]
 testdir = "0.9.1"

--- a/src/nerdbank-zcash-rust/src/analysis.rs
+++ b/src/nerdbank-zcash-rust/src/analysis.rs
@@ -201,7 +201,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio_shared_rt::test(flavor = "multi_thread")]
     async fn test_get_birthday_heights() {
         let mut setup = setup_test().await;
         let (_, _, account_id, _) = setup.create_account().await.unwrap();
@@ -211,7 +211,7 @@ mod tests {
         assert_matches!(heights.rebirth_height, None);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio_shared_rt::test(flavor = "multi_thread")]
     async fn test_get_user_balances() {
         let mut setup = setup_test().await;
         let (_, _, account_id, _) = setup.create_account().await.unwrap();

--- a/src/nerdbank-zcash-rust/src/backing_store.rs
+++ b/src/nerdbank-zcash-rust/src/backing_store.rs
@@ -122,7 +122,7 @@ mod tests {
     use super::*;
     use testdir::testdir;
 
-    #[tokio::test]
+    #[tokio_shared_rt::test]
     async fn test_init() {
         let wallet_dir = testdir!();
         let data_file = wallet_dir.join("wallet.sqlite");

--- a/src/nerdbank-zcash-rust/src/lightclient.rs
+++ b/src/nerdbank-zcash-rust/src/lightclient.rs
@@ -42,7 +42,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[tokio_shared_rt::test]
     async fn test_get_block_height() {
         let block_height = get_block_height(LIGHTSERVER_URI.to_owned(), CancellationToken::new())
             .await

--- a/src/nerdbank-zcash-rust/src/send.rs
+++ b/src/nerdbank-zcash-rust/src/send.rs
@@ -170,7 +170,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[tokio_shared_rt::test]
     async fn test_send_insufficient_funds() {
         let mut setup = setup_test().await;
         let account = setup.create_account().await.unwrap();

--- a/src/nerdbank-zcash-rust/src/shield.rs
+++ b/src/nerdbank-zcash-rust/src/shield.rs
@@ -113,7 +113,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio_shared_rt::test(flavor = "multi_thread")]
     async fn test_get_unshielded_utxos() {
         let mut setup = setup_test().await;
         let (_, _, account_id, _) = setup.create_account().await.unwrap();

--- a/src/nerdbank-zcash-rust/src/sync.rs
+++ b/src/nerdbank-zcash-rust/src/sync.rs
@@ -1088,7 +1088,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio_shared_rt::test(flavor = "multi_thread")]
     async fn test_sync() {
         let mut setup = setup_test().await;
         let (seed, birthday, account_id, _) = setup.create_account().await.unwrap();


### PR DESCRIPTION
This reverts part of commit 4a2fe0cf971766930019d6a52f31e32b818dae2f and fixes the test instability in a better way as tipped off by @AmeliasCode in [this comment](https://github.com/hyperium/tonic/issues/1751#issuecomment-2184534663) and specifically shared by @gwy15 in [this comment](https://github.com/tokio-rs/tokio/issues/2374#issuecomment-1564092469).

It seems the problem was that after the first test finished, the runtime that 'owned' the Mutex or channel was shut down, breaking it for all subsequent users. By changing our tests to all use a shared runtime, the channel isn't killed and can therefore work in subsequent tests.