### PR TITLE
Revert "Set optimized and rebirth heights to block *before* note"

### DIFF
--- a/src/nerdbank-zcash-rust/src/analysis.rs
+++ b/src/nerdbank-zcash-rust/src/analysis.rs
@@ -34,19 +34,13 @@ pub fn get_birthday_heights(
         named_params! {
             ":account_id": u32::from(account_id),
         },
-        |row| {
-            Ok((
-                row.get(0)?,
-                row.get::<_, Option<u32>>(1)?,
-                row.get::<_, Option<u32>>(2)?,
-            ))
-        },
+        |row| Ok((row.get(0)?, row.get::<_, Option<u32>>(1)?, row.get(2)?)),
     )?;
 
     Ok(BirthdayHeights {
         original_birthday_height: heights.0,
-        birthday_height: heights.1.map(|h| h - 1),
-        rebirth_height: heights.2.map(|h| h - 1),
+        birthday_height: heights.1,
+        rebirth_height: heights.2,
     })
 }
 


### PR DESCRIPTION
This reverts commit 55d4d623d4e53516af391b4011d2d7e91ed2e60d, which supposedly "fixed" #344 but it turns out the proposed behavior was wrong.