### PR TITLE
Account recovery improvements

### DIFF
--- a/src/Nerdbank.Zcash/Transaction.cs
+++ b/src/Nerdbank.Zcash/Transaction.cs
@@ -8,6 +8,7 @@ namespace Nerdbank.Zcash;
 /// <summary>
 /// Describes a Zcash transaction.
 /// </summary>
+[DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
 public partial record Transaction
 {
 	/// <summary>
@@ -96,4 +97,6 @@ public partial record Transaction
 	/// Gets a value indicating whether this transaction did not originate from this account.
 	/// </summary>
 	public bool IsIncoming => this.Outgoing.IsEmpty;
+
+	private string DebuggerDisplay => $"{this.NetChange:+0.########;-0.########} {this.TransactionId.ToString()[..6]}..{this.TransactionId.ToString()[^6..]} ({this.MinedHeight})";
 }

--- a/src/nerdbank-zcash-rust/src/ffi.udl
+++ b/src/nerdbank-zcash-rust/src/ffi.udl
@@ -14,6 +14,12 @@ enum ChainType {
 	"Mainnet",
 };
 
+enum Pool {
+	"Transparent",
+	"Sapling",
+	"Orchard",
+};
+
 dictionary AccountInfo {
 	u32 id;
 	string? uvk;
@@ -42,6 +48,7 @@ dictionary TransactionNote {
 	u64 value;
 	bytes? memo;
 	string recipient;
+	Pool pool;
 };
 
 dictionary TransactionSendDetail {

--- a/src/nerdbank-zcash-rust/src/interop.rs
+++ b/src/nerdbank-zcash-rust/src/interop.rs
@@ -67,6 +67,13 @@ pub enum ChainType {
     Testnet,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum Pool {
+    Transparent,
+    Sapling,
+    Orchard,
+}
+
 impl From<ChainType> for Network {
     fn from(chain_type: ChainType) -> Self {
         match chain_type {
@@ -117,6 +124,7 @@ pub struct TransparentNote {
 #[derive(Debug, Clone)]
 pub struct TransactionNote {
     pub recipient: String,
+    pub pool: Pool,
     pub value: u64,
     pub memo: Option<Vec<u8>>,
 }

--- a/src/nerdbank-zcash-rust/src/lib.rs
+++ b/src/nerdbank-zcash-rust/src/lib.rs
@@ -28,6 +28,6 @@ use interop::{
     get_birthday_heights, get_block_height, get_sync_height, get_transactions,
     get_unshielded_utxos, get_user_balances, import_account_ufvk, init, send, shield,
     simulate_send, sync, AccountInfo, CancellationSource, ChainType, DbInit, LightWalletError,
-    SendDetails, SendTransactionResult, SyncUpdate, SyncUpdateData, Transaction, TransactionNote,
-    TransactionSendDetail, TransparentNote,
+    Pool, SendDetails, SendTransactionResult, SyncUpdate, SyncUpdateData, Transaction,
+    TransactionNote, TransactionSendDetail, TransparentNote,
 };

--- a/src/nerdbank-zcash-rust/src/sql_statements.rs
+++ b/src/nerdbank-zcash-rust/src/sql_statements.rs
@@ -38,12 +38,13 @@ pub(crate) const GET_TRANSACTIONS_SQL: &str = r#"
 	LEFT OUTER JOIN transactions tx ON tx.txid = t.txid
 	LEFT OUTER JOIN sapling_received_notes s ON txo.output_pool = 2 AND s.tx = tx.id_tx AND s.output_index = txo.output_index
 	LEFT OUTER JOIN orchard_received_notes o ON txo.output_pool = 3 AND o.tx = tx.id_tx AND o.action_index = txo.output_index
-	WHERE (:account_id IS NULL OR (t.account_id = :account_id AND (txo.from_account_id = :account_id OR txo.to_account_id = :account_id)))
+	WHERE (:account_id IS NULL OR t.account_id = :account_id)
+		AND (from_account_id = t.account_id OR txo.to_account_id = t.account_id)
 		AND (from_account_id IS NOT NULL OR to_account_id IS NOT NULL) -- ignore transactions that probably aren't fully initialized
 		AND (t.mined_height IS NULL OR :starting_block IS NULL OR t.mined_height >= :starting_block)
 		AND (t.mined_height IS NULL OR :ending_block IS NULL OR t.mined_height <= :ending_block)
-	GROUP BY tx.id_tx, t.account_id, txo.output_pool, txo.output_index
-	ORDER BY t.mined_height, t.tx_index, txo.output_pool, txo.output_index -- ensure rows that get squashed together are next to each other
+	GROUP BY t.account_id, tx.id_tx, t.account_id, txo.output_pool, txo.output_index
+	ORDER BY t.account_id, t.mined_height, t.tx_index, txo.output_pool, txo.output_index -- ensure rows that get squashed together are next to each other
 "#;
 
 // TODO: update this to consider UTXOs in "Block with first unspent note" column.

--- a/src/nerdbank-zcash-rust/src/sync.rs
+++ b/src/nerdbank-zcash-rust/src/sync.rs
@@ -184,7 +184,7 @@ pub async fn sync<P: AsRef<Path>>(
                     network,
                     None,
                     Some(range.start.into()),
-                    Some(range.end.into()),
+                    Some((range.end - 1).into()),
                 )?
                 .to_vec();
                 if !new_transactions.is_empty() {
@@ -929,6 +929,9 @@ async fn watch_mempool(client: &mut CompactTxStreamerClient<Channel>) -> Result<
     Ok(())
 }
 
+/// Returns the transactions that match the given filters.
+///
+/// `starting_block_filter` and `ending_block_filter` are inclusive.
 pub(crate) fn get_transactions(
     db: &mut Db,
     conn: &mut rusqlite::Connection,

--- a/src/nerdbank-zcash-rust/src/sync.rs
+++ b/src/nerdbank-zcash-rust/src/sync.rs
@@ -41,6 +41,7 @@ use zcash_client_backend::{
         },
     },
     wallet::WalletTransparentOutput,
+    PoolType,
 };
 
 use crate::{
@@ -48,7 +49,7 @@ use crate::{
     block_source::BlockCacheError,
     error::Error,
     grpc::get_client,
-    interop::{SyncUpdate, SyncUpdateData, TransactionNote},
+    interop::{Pool, SyncUpdate, SyncUpdateData, TransactionNote},
     lightclient::parse_network,
     resilience::webrequest_with_retry,
     sql_statements::GET_TRANSACTIONS_SQL,
@@ -962,6 +963,17 @@ pub(crate) fn get_transactions(
             let memo: Option<Vec<u8>> = row.get("memo")?;
             let memo = memo.unwrap_or_default();
 
+            let output_pool = match output_pool {
+                0 => PoolType::Transparent,
+                2 => PoolType::SAPLING,
+                3 => PoolType::ORCHARD,
+                _ => {
+                    return Err(Error::SqliteClient(SqliteClientError::CorruptedData(
+                        format!("Unknown output pool type: {}", output_pool),
+                    )))
+                }
+            };
+
             let ufvk = ufvkeys.get(&AccountId::from(account_id));
 
             // Work out the receiving address when the sqlite db doesn't record it
@@ -970,7 +982,7 @@ pub(crate) fn get_transactions(
                 let diversifier: Option<Vec<u8>> = row.get("diversifier")?;
                 if let Some(diversifier) = diversifier {
                     recipient = match output_pool {
-                        2 => ufvk.and_then(|k| {
+                        PoolType::SAPLING => ufvk.and_then(|k| {
                             k.sapling().and_then(|s| {
                                 s.diversified_address(sapling::keys::Diversifier(
                                     diversifier.try_into().unwrap(),
@@ -978,7 +990,7 @@ pub(crate) fn get_transactions(
                                 .map(|a| a.encode(network))
                             })
                         }),
-                        3 => ufvk.and_then(|k| {
+                        PoolType::ORCHARD => ufvk.and_then(|k| {
                             k.orchard().map(|o| {
                                 UnifiedAddress::from_receivers(
                                     Some(o.address(
@@ -1029,6 +1041,11 @@ pub(crate) fn get_transactions(
             let note = TransactionNote {
                 value,
                 recipient: recipient.clone().unwrap(),
+                pool: match output_pool {
+                    PoolType::Transparent => Pool::Transparent,
+                    PoolType::SAPLING => Pool::Sapling,
+                    PoolType::ORCHARD => Pool::Orchard,
+                },
                 memo: if memo.is_empty() {
                     None
                 } else {
@@ -1041,7 +1058,7 @@ pub(crate) fn get_transactions(
             // * the recipient is shielded (since change will never be sent to the transparent pool).
             // * the memo does not contain user text,
             let is_change = to_account_id == from_account_id
-                && output_pool > 1
+                && matches!(output_pool, PoolType::Shielded(_))
                 && Memo::from_bytes(&memo).is_ok_and(|m| !matches!(m, Memo::Text(_)));
 
             if is_change {

--- a/src/nerdbank-zcash-rust/src/sync.rs
+++ b/src/nerdbank-zcash-rust/src/sync.rs
@@ -1066,7 +1066,7 @@ pub(crate) fn get_transactions(
         let mut row = row_result?;
 
         let last = result.last();
-        let add = last.is_some() && last.unwrap().txid.eq(&row.txid);
+        let add = last.is_some_and(|l| l.account_id == row.account_id && l.txid.eq(&row.txid));
         if add {
             // This row adds line items to the last transaction.
             // Pop it off the list to change it, then we'll add it back.


### PR DESCRIPTION
This pull request includes several changes to the `Nerdbank.Zcash` project, mainly focusing on transaction handling and data structures. The changes include the addition of a `Pool` enum and its integration into the `TransactionNote` struct, modifications to the `Transaction` class in `Transaction.cs`, and alterations to SQL statements in `sql_statements.rs`.

Changes to data structures:

* [`src/nerdbank-zcash-rust/src/interop.rs`](diffhunk://#diff-0cd55626789e13a45ef396fe0fcdde5986fadd056f0da45799b97df77f8beb92R70-R76): Added a `Pool` enum and integrated it into the `TransactionNote` struct. [[1]](diffhunk://#diff-0cd55626789e13a45ef396fe0fcdde5986fadd056f0da45799b97df77f8beb92R70-R76) [[2]](diffhunk://#diff-0cd55626789e13a45ef396fe0fcdde5986fadd056f0da45799b97df77f8beb92R127)
* [`src/nerdbank-zcash-rust/src/ffi.udl`](diffhunk://#diff-63303c6c24c3bf1c40b9579b45af3fe8e3d86a11b31f07d771538135da8e83d3R17-R22): Added a `Pool` enum and integrated it into the `TransactionNote` dictionary. [[1]](diffhunk://#diff-63303c6c24c3bf1c40b9579b45af3fe8e3d86a11b31f07d771538135da8e83d3R17-R22) [[2]](diffhunk://#diff-63303c6c24c3bf1c40b9579b45af3fe8e3d86a11b31f07d771538135da8e83d3R51)
* [`src/Nerdbank.Zcash/RustBindings/LightWallet.cs`](diffhunk://#diff-e77d5de86ea52758ac65a351034b4c41382f5793ad411ef06de2db2789d23696L1754-R1754): Added a `Pool` enum and integrated it into the `TransactionNote` record. [[1]](diffhunk://#diff-e77d5de86ea52758ac65a351034b4c41382f5793ad411ef06de2db2789d23696L1754-R1754) [[2]](diffhunk://#diff-e77d5de86ea52758ac65a351034b4c41382f5793ad411ef06de2db2789d23696L1765-R1783) [[3]](diffhunk://#diff-e77d5de86ea52758ac65a351034b4c41382f5793ad411ef06de2db2789d23696R2107-R2143)
* [`src/Nerdbank.Zcash/Transaction.cs`](diffhunk://#diff-c829b57d0902bc5d246f3971dd8a55db3624315c5cda188ceb5b9ac1019a8f1eR11): Added a `DebuggerDisplay` attribute to the `Transaction` class and a `DebuggerDisplay` property. [[1]](diffhunk://#diff-c829b57d0902bc5d246f3971dd8a55db3624315c5cda188ceb5b9ac1019a8f1eR11) [[2]](diffhunk://#diff-c829b57d0902bc5d246f3971dd8a55db3624315c5cda188ceb5b9ac1019a8f1eR100-R101)

Changes to transaction handling:

* [`src/Nerdbank.Zcash/LightWalletClient.cs`](diffhunk://#diff-8ab7360cebac85d45d95fde2ebb7cde7c34a6748f9f383054e63c9d2350de70fL466-R483): Modified the `CreateLineItem` method to handle excess receivers and use standard encodings for each pool.
* [`src/nerdbank-zcash-rust/src/sync.rs`](diffhunk://#diff-1123c83872f892ad5eb45c7c6292212c11fe88e3db7c3fa82853565c204349f4R966-R976): Made changes to the `get_transactions` function to accommodate the new `Pool` enum and handle transactions accordingly. [[1]](diffhunk://#diff-1123c83872f892ad5eb45c7c6292212c11fe88e3db7c3fa82853565c204349f4R966-R976) [[2]](diffhunk://#diff-1123c83872f892ad5eb45c7c6292212c11fe88e3db7c3fa82853565c204349f4L970-R993) [[3]](diffhunk://#diff-1123c83872f892ad5eb45c7c6292212c11fe88e3db7c3fa82853565c204349f4R1044-R1048) [[4]](diffhunk://#diff-1123c83872f892ad5eb45c7c6292212c11fe88e3db7c3fa82853565c204349f4L1041-R1061) [[5]](diffhunk://#diff-1123c83872f892ad5eb45c7c6292212c11fe88e3db7c3fa82853565c204349f4L1066-R1086)

Changes to SQL statements:

* [`src/nerdbank-zcash-rust/src/sql_statements.rs`](diffhunk://#diff-23a0a0e1115604a5fd665261b559f2c9011c2b9751af56147d49a0473593fce2L32-R32): Modified the `GET_TRANSACTIONS_SQL` constant to accommodate changes in transaction handling. [[1]](diffhunk://#diff-23a0a0e1115604a5fd665261b559f2c9011c2b9751af56147d49a0473593fce2L32-R32) [[2]](diffhunk://#diff-23a0a0e1115604a5fd665261b559f2c9011c2b9751af56147d49a0473593fce2R42-R47)