### PR TITLE
Reject bech32 encodings with mixed case

### DIFF
--- a/src/Nerdbank.Cryptocurrencies/Strings.es.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.es.resx
@@ -153,6 +153,9 @@
   <data name="MissingBech32Separator" xml:space="preserve">
     <value>¡No se ha encontrado ningún carácter separador '1'.</value>
   </data>
+  <data name="MixedCaseBech32" xml:space="preserve">
+    <value>La codificación debe ser todo minúscula o en mayúsculas, pero contiene un caso mixto.</value>
+  </data>
   <data name="SecurityMismatch" xml:space="preserve">
     <value>Esta operación requiere que todas las entradas sean del mismo tipo de seguridad.</value>
   </data>

--- a/src/Nerdbank.Cryptocurrencies/Strings.fr.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.fr.resx
@@ -153,6 +153,9 @@
   <data name="MissingBech32Separator" xml:space="preserve">
     <value>Aucun caractère de séparation '1' trouvé.</value>
   </data>
+  <data name="MixedCaseBech32" xml:space="preserve">
+    <value>L'encodage doit être en minuscules ou toutes les majuscules, mais contient un boîtier mixte.</value>
+  </data>
   <data name="SecurityMismatch" xml:space="preserve">
     <value>Cette opération nécessite que toutes les entrées soient du même type de sécurité.</value>
   </data>

--- a/src/Nerdbank.Cryptocurrencies/Strings.ko.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.ko.resx
@@ -153,6 +153,9 @@
   <data name="MissingBech32Separator" xml:space="preserve">
     <value>'1' 구분 기호 문자가 없습니다.</value>
   </data>
+  <data name="MixedCaseBech32" xml:space="preserve">
+    <value>인코딩은 모두 소문자 또는 모든 대문자이어야하지만 혼합 케이스가 포함되어 있어야합니다.</value>
+  </data>
   <data name="SecurityMismatch" xml:space="preserve">
     <value>이 작업은 모든 입력이 동일한 보안 유형이어야 합니다.</value>
   </data>

--- a/src/Nerdbank.Cryptocurrencies/Strings.pt.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.pt.resx
@@ -153,6 +153,9 @@
   <data name="MissingBech32Separator" xml:space="preserve">
     <value>Nenhum caractere separador '1' encontrado.</value>
   </data>
+  <data name="MixedCaseBech32" xml:space="preserve">
+    <value>A codificação deve ser toda minúscula ou toda a maçaneta, mas contém um estojo misto.</value>
+  </data>
   <data name="SecurityMismatch" xml:space="preserve">
     <value>Esta operação requer que todas as entradas sejam do mesmo tipo de segurança.</value>
   </data>

--- a/src/Nerdbank.Cryptocurrencies/Strings.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.resx
@@ -153,6 +153,9 @@
   <data name="MissingBech32Separator" xml:space="preserve">
     <value>No '1' separator character found.</value>
   </data>
+  <data name="MixedCaseBech32" xml:space="preserve">
+    <value>The encoding must be all lowercase or all uppercase, but contains a mixed case.</value>
+  </data>
   <data name="SecurityMismatch" xml:space="preserve">
     <value>This operation requires all inputs to be of the same security type.</value>
   </data>

--- a/src/Nerdbank.Cryptocurrencies/Strings.ru.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.ru.resx
@@ -153,6 +153,9 @@
   <data name="MissingBech32Separator" xml:space="preserve">
     <value>Нет «1» персонажа сепаратора.</value>
   </data>
+  <data name="MixedCaseBech32" xml:space="preserve">
+    <value>Кодирование должно быть все строчное или все прописное, но содержит смешанный корпус.</value>
+  </data>
   <data name="SecurityMismatch" xml:space="preserve">
     <value>Эта операция требует, чтобы все входы были одинаковыми типом безопасности.</value>
   </data>

--- a/src/Nerdbank.Cryptocurrencies/Strings.zh-Hans.resx
+++ b/src/Nerdbank.Cryptocurrencies/Strings.zh-Hans.resx
@@ -153,6 +153,9 @@
   <data name="MissingBech32Separator" xml:space="preserve">
     <value>未找到 '1' 分隔符字符。</value>
   </data>
+  <data name="MixedCaseBech32" xml:space="preserve">
+    <value>编码必须全部是小写或所有大写，但包含一个混合的情况。</value>
+  </data>
   <data name="SecurityMismatch" xml:space="preserve">
     <value>此操作要求所有输入都是相同的安全类型。</value>
   </data>

--- a/test/Nerdbank.Cryptocurrencies.Tests/Bech32Tests.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Bech32Tests.cs
@@ -28,6 +28,7 @@ public class Bech32Tests
 		new object?[] { ("sometag", "abcdef0110ffeedd"), "sometag140x77qgsllhd6qcua60" },
 		new object?[] { ("sometag", "abcdef0110ffeeddc0ffee"), "sometag140x77qgsllhdms8lacykfwm3" },
 		new object?[] { ("somet1ag", "abcdef0110ffeedd"), "somet1ag140x77qgsllhd6sjr0yn" },
+		new object?[] { ("123", "abcdef0110ffeedd"), "123140x77qgsllhd60q22cl" },
 	};
 
 	/// <summary>
@@ -152,6 +153,75 @@ public class Bech32Tests
 		Assert.False(Bech32.Original.TryDecode("my14vf0uubr", tag, data, out DecodeError? error, out string? msg, out (int Tag, int Data) length));
 		Assert.Equal(DecodeError.InvalidCharacter, error);
 		this.logger.WriteLine(msg);
+	}
+
+	/// <summary>
+	/// Verifies that mixed case bech32 encodings are rejected, even if they would be valid as all lowercase or all uppercase.
+	/// This is a "MUST" condition in the Bech32 spec.
+	/// </summary>
+	[Fact]
+	public void TryDecode_MixedCaseInData()
+	{
+		Span<char> tag = stackalloc char[10];
+		Span<byte> data = stackalloc byte[10];
+		Assert.False(Bech32.Original.TryDecode("my140xshf6D6q", tag, data, out DecodeError? decodeResult, out string? errorMessage, out (int Tag, int Data) length));
+		this.logger.WriteLine(errorMessage);
+		Assert.Equal(DecodeError.InvalidCharacter, decodeResult);
+	}
+
+	/// <summary>
+	/// Verifies that mixed case bech32 encodings are rejected, even if they would be valid as all lowercase or all uppercase.
+	/// This is a "MUST" condition in the Bech32 spec.
+	/// </summary>
+	[Fact]
+	public void TryDecode_MixedCaseInDataWithNoCaseInTag()
+	{
+		Span<char> tag = stackalloc char[10];
+		Span<byte> data = stackalloc byte[10];
+		Assert.False(Bech32.Original.TryDecode("123140x77qgsllhd60q22Cl", tag, data, out DecodeError? decodeResult, out string? errorMessage, out (int Tag, int Data) length));
+		this.logger.WriteLine(errorMessage);
+		Assert.Equal(DecodeError.InvalidCharacter, decodeResult);
+	}
+
+	/// <summary>
+	/// Verifies that mixed case bech32 encodings are rejected, even if they would be valid as all lowercase or all uppercase.
+	/// This is a "MUST" condition in the Bech32 spec.
+	/// </summary>
+	[Fact]
+	public void TryDecode_MixedCaseInTag()
+	{
+		Span<char> tag = stackalloc char[10];
+		Span<byte> data = stackalloc byte[10];
+		Assert.False(Bech32.Original.TryDecode("My140xshf6d6q", tag, data, out DecodeError? decodeResult, out string? errorMessage, out (int Tag, int Data) length));
+		this.logger.WriteLine(errorMessage);
+		Assert.Equal(DecodeError.InvalidCharacter, decodeResult);
+	}
+
+	/// <summary>
+	/// Verifies that mixed case bech32 encodings are rejected, even if they would be valid as all lowercase or all uppercase.
+	/// This is a "MUST" condition in the Bech32 spec.
+	/// </summary>
+	[Fact]
+	public void TryDecode_MixedCaseBetweenTagAndData()
+	{
+		Span<char> tag = stackalloc char[10];
+		Span<byte> data = stackalloc byte[10];
+		Assert.False(Bech32.Original.TryDecode("MY140xshf6d6q", tag, data, out DecodeError? decodeResult, out string? errorMessage, out (int Tag, int Data) length));
+		this.logger.WriteLine(errorMessage);
+		Assert.Equal(DecodeError.InvalidCharacter, decodeResult);
+	}
+
+	[Fact]
+	public void TryDecode_Uppercase()
+	{
+		Span<char> tag = stackalloc char[10];
+		Span<byte> data = stackalloc byte[10];
+		Assert.True(Bech32.Original.TryDecode("MY140XSHF6D6Q", tag, data, out DecodeError? decodeResult, out string? errorMessage, out (int Tag, int Data) length));
+		this.logger.WriteLine($"Tag: {tag[..length.Tag].ToString()} Data: {Convert.ToHexString(data[..length.Data])}");
+		Assert.Equal("my", tag[..length.Tag].ToString());
+		Assert.Equal("ABCD", Convert.ToHexString(data[..length.Data]));
+		Assert.Null(errorMessage);
+		Assert.Null(decodeResult);
 	}
 
 	[Theory, MemberData(nameof(Bech32Pairings))]


### PR DESCRIPTION
This is a "MUST" requirement of bech32, which we were previously missing compliance with.