### PR TITLE
Provide more precise import functions

### DIFF
--- a/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Zcash/PublicAPI.Unshipped.txt
@@ -950,6 +950,7 @@ static Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys.operator !=(Nerdbank.Zca
 static Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys.operator ==(Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys? left, Nerdbank.Zcash.ZcashAccount.InternalSpendingKeys? right) -> bool
 static Nerdbank.Zcash.ZcashAccount.SpendingKeys.operator !=(Nerdbank.Zcash.ZcashAccount.SpendingKeys? left, Nerdbank.Zcash.ZcashAccount.SpendingKeys? right) -> bool
 static Nerdbank.Zcash.ZcashAccount.SpendingKeys.operator ==(Nerdbank.Zcash.ZcashAccount.SpendingKeys? left, Nerdbank.Zcash.ZcashAccount.SpendingKeys? right) -> bool
+static Nerdbank.Zcash.ZcashAccount.TryImportAccount(Nerdbank.Cryptocurrencies.IKey! key, out Nerdbank.Zcash.ZcashAccount? account) -> bool
 static Nerdbank.Zcash.ZcashAccount.TryImportAccount(string! encodedKey, out Nerdbank.Zcash.ZcashAccount? account) -> bool
 static Nerdbank.Zcash.ZcashAddress.Decode(string! address) -> Nerdbank.Zcash.ZcashAddress!
 static Nerdbank.Zcash.ZcashAddress.implicit operator string?(Nerdbank.Zcash.ZcashAddress? address) -> string?

--- a/src/Nerdbank.Zcash/ZcashUtilities.cs
+++ b/src/Nerdbank.Zcash/ZcashUtilities.cs
@@ -67,6 +67,8 @@ public static class ZcashUtilities
 	/// </remarks>
 	public static bool TryParseKey(string encodedKey, [NotNullWhen(true)] out IKeyWithTextEncoding? key)
 	{
+		Requires.NotNull(encodedKey);
+
 		if (UnifiedViewingKey.TryDecode(encodedKey, out _, out _, out UnifiedViewingKey? unifiedViewingKey))
 		{
 			key = unifiedViewingKey;


### PR DESCRIPTION
This allows the driver to distinguish between unsupported zcash *keys* and unsupported zcash *accounts*.