### PR TITLE
Enable MSBuild project cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+MSBuildCacheLogs/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,6 +44,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <CI Condition="'$(TF_BUILD)'=='true'">true</CI>
+
+    <!-- Avoid file write collisions when building multiple times with the MSBuild Project Cache plugin active. -->
+    <MSBuildCacheIdenticalDuplicateOutputPatterns>$(MSBuildCacheIdenticalDuplicateOutputPatterns);**</MSBuildCacheIdenticalDuplicateOutputPatterns>
+    <MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>$(MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns);$(LocalAppData)\Microsoft\Windows\INetCache\**</MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -14,3 +14,4 @@
 /m
 /verbosity:minimal
 /clp:Summary;ForceNoAlign
+/graph

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,12 @@
     <RoslynVersion>3.11.0-beta1.24104.1</RoslynVersion>
     <AspNetWebAssemblyVersion>8.0.7</AspNetWebAssemblyVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- In Azure pipelines, use Pipeline Caching as the cache storage backend. Otherwise, use the local cache. -->
+    <MSBuildCachePackageName Condition="'$(TF_BUILD)' != ''">Microsoft.MSBuildCache.AzurePipelines</MSBuildCachePackageName>
+    <MSBuildCachePackageName Condition="'$(MSBuildCachePackageName)' == ''">Microsoft.MSBuildCache.Local</MSBuildCachePackageName>
+    <MSBuildCachePackageVersion>0.1.287-preview</MSBuildCachePackageVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.27.2" />
@@ -35,9 +41,13 @@
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="$(RoslynVersion)" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="$(RoslynVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+    <GlobalPackageReference Include="$(MSBuildCachePackageName)" Version="$(MSBuildCachePackageVersion)" />
+    <GlobalPackageReference Include="Microsoft.MSBuildCache.SharedCompilation" Version="$(MSBuildCachePackageVersion)" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -7,6 +7,16 @@ steps:
 - pwsh: dotnet build -t:build,publish --no-restore -c $(BuildConfiguration) -warnaserror /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
   displayName: 🛠️ dotnet build
   workingDirectory: azure-pipelines
+  condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT'))
+
+- task: MSBuild@1
+  inputs:
+    solution: '*.sln'
+    msbuildArguments: /t:build,publish /warnaserror /reportfileaccesses /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
+    configuration: $(BuildConfiguration)
+    msbuildArchitecture: x64
+  displayName: 🛠️ MSBuild
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - powershell: azure-pipelines/dotnet-test-cloud.ps1 -Configuration $(BuildConfiguration) -Agent $(Agent.JobName) -PublishResults
   displayName: 🧪 dotnet test


### PR DESCRIPTION
This could make Azure Pipelines builds somewhat faster around the msbuild step on Windows.