### PR TITLE
Build on macOS 15 (Sequoia)

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -77,7 +77,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS-14
+    vmImage: macOS-15
   variables:
   - name: DEVELOPER_DIR
     value: /Applications/Xcode_16.app/Contents/Developer


### PR DESCRIPTION
This is necessary due to this breaking change in Azure Pipelines/GitHub's hosted agents:
https://github.com/actions/runner-images/issues/10703
