### PR TITLE
Fix `dotnet workload restore` failure

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -116,7 +116,7 @@ try {
 
     if (!$NoRestore -and $PSCmdlet.ShouldProcess(".NET workloads", "Restore")) {
         Write-Host "Restoring applicable .NET workloads" -ForegroundColor $HeaderColor
-        dotnet workload restore
+        dotnet workload restore (Join-Path $PSScriptRoot Nerdbank.Cryptocurrencies.sln)
         if ($lastexitcode -ne 0) {
             throw "Failure while restoring workloads."
         }


### PR DESCRIPTION
When the MSBuild traversal SDK is not already installed, `dotnet workload restore` fails. When I run `dotnet restore` first (to place the SDK) it fails saying I must first run `dotnet workload restore`.

By running `dotnet workload restore` _first_, targeting the sln file instead of the traversal project, I avoid the traversal SDK dependency, allowing workload restore to succeed, which then allows a subsequent traversal project-based `dotnet restore` to succeed.

See also https://github.com/dotnet/sdk/issues/45447