### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,21 +10,21 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.12.6",
+      "version": "17.13.1",
       "commands": [
         "dotnet-coverage"
       ],
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.6.146",
+      "version": "3.7.112",
       "commands": [
         "nbgv"
       ],
       "rollForward": false
     },
     "docfx": {
-      "version": "2.78.1",
+      "version": "2.78.2",
       "commands": [
         "docfx"
       ],

--- a/.github/actions/publish-artifacts/action.yaml
+++ b/.github/actions/publish-artifacts/action.yaml
@@ -1,0 +1,67 @@
+name: Publish artifacts
+description: Publish artifacts
+
+runs:
+  using: composite
+  steps:
+  - name: 📥 Collect artifacts
+    run: azure-pipelines/artifacts/_stage_all.ps1
+    shell: pwsh
+    if: always()
+
+# TODO: replace this hard-coded list with a loop that utilizes the NPM package at
+# https://github.com/actions/toolkit/tree/main/packages/artifact (or similar) to push the artifacts.
+
+  - name: 📢 Upload project.assets.json files
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: projectAssetsJson-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/projectAssetsJson
+    continue-on-error: true
+  - name: 📢 Upload variables
+    uses: actions/upload-artifact@v4
+    with:
+      name: variables-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/Variables
+    continue-on-error: true
+  - name: 📢 Upload build_logs
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: build_logs-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/build_logs
+    continue-on-error: true
+  - name: 📢 Upload test_logs
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: test_logs-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/test_logs
+    continue-on-error: true
+  - name: 📢 Upload testResults
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: testResults-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/testResults
+    continue-on-error: true
+  - name: 📢 Upload coverageResults
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: coverageResults-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/coverageResults
+    continue-on-error: true
+  - name: 📢 Upload symbols
+    uses: actions/upload-artifact@v4
+    with:
+      name: symbols-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/symbols
+    continue-on-error: true
+  - name: 📢 Upload deployables
+    uses: actions/upload-artifact@v4
+    with:
+      name: deployables-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/deployables
+    if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ permissions:
   actions: read
   pages: write
   id-token: write
+  contents: read
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -25,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites
 

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -1,4 +1,4 @@
-name: Library.Template update
+name: ⛜ Library.Template update
 
 # PREREQUISITE: This workflow requires the repo to be configured to allow workflows to create pull requests.
 # Visit https://github.com/USER/REPO/settings/actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: 🎁 Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ship_run_id:
+        description: ID of the GitHub workflow run to ship
+        required: true
+
+run-name: ${{ github.ref_name }}
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: ⚙️ Initialization
+      shell: pwsh
+      run: |
+        if ('${{ secrets.NUGET_API_KEY }}') {
+          Write-Host "NUGET_API_KEY secret detected. NuGet packages will be pushed."
+          echo "NUGET_API_KEY_DEFINED=true" >> $env:GITHUB_ENV
+        }
+
+    - name: 🔎 Search for build of ${{ github.ref }}
+      shell: pwsh
+      id: findrunid
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if ('${{ inputs.ship_run_id }}') {
+          $runid = '${{ inputs.ship_run_id }}'
+        } else {
+          $restApiRoot = '/repos/${{ github.repository }}'
+
+          # Resolve the tag reference to a commit sha
+          $resolvedRef = gh api `
+            -H "Accept: application/vnd.github+json" `
+            -H "X-GitHub-Api-Version: 2022-11-28" `
+            $restApiRoot/git/ref/tags/${{ github.ref_name }} `
+            | ConvertFrom-Json
+          $commitSha = $resolvedRef.object.sha
+
+          Write-Host "Resolved ${{ github.ref_name }} to $commitSha"
+
+          $releases = gh run list -R ${{ github.repository }} -c $commitSha -w .github/workflows/build.yml -s success --json databaseId,startedAt `
+            | ConvertFrom-Json | Sort-Object startedAt -Descending
+
+          if ($releases.length -eq 0) {
+            Write-Error "No successful builds found for ${{ github.ref }}."
+          } elseif ($releases.length -gt 1) {
+            Write-Warning "More than one successful run found for ${{ github.ref }}. Artifacts from the most recent successful run will ship."
+          }
+
+          $runid = $releases[0].databaseId
+        }
+
+        Write-Host "Using artifacts from run-id: $runid"
+
+        Echo "runid=$runid" >> $env:GITHUB_OUTPUT
+
+    - name: 🔻 Download deployables artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: deployables-Linux
+        path: ${{ runner.temp }}/deployables
+        run-id: ${{ steps.findrunid.outputs.runid }}
+        github-token: ${{ github.token }}
+
+    - name: 💽 Upload artifacts to release
+      shell: pwsh
+      if: ${{ github.event.release.assets_url }} != ''
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        Get-ChildItem '${{ runner.temp }}/deployables' |% {
+          Write-Host "Uploading $($_.Name) to release..."
+          gh release -R ${{ github.repository }} upload "${{ github.ref_name }}" $_.FullName
+        }
+
+    - name: 🚀 Push NuGet packages
+      run: dotnet nuget push ${{ runner.temp }}/deployables/*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ secrets.NUGET_API_KEY }}'
+      if: ${{ env.NUGET_API_KEY_DEFINED == 'true' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,29 @@ When adding or updating just one string in an existing file, the following AI pr
 
 [pwsh]: https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-6
 
+## Releases
+
+Use `nbgv tag` to create a tag for a particular commit that you mean to release.
+[Learn more about `nbgv` and its `tag` and `prepare-release` commands](https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/nbgv-cli.md).
+
+Push the tag.
+
+### GitHub Actions
+
+When your repo is hosted by GitHub and you are using GitHub Actions, you should create a GitHub Release using the standard GitHub UI.
+Having previously used `nbgv tag` and pushing the tag will help you identify the precise commit and name to use for this release.
+
+After publishing the release, the `.github\workflows\release.yml` workflow will be automatically triggered, which will:
+
+1. Find the most recent `.github\workflows\build.yml` GitHub workflow run of the tagged release.
+1. Upload the `deployables` artifact from that workflow run to your GitHub Release.
+1. If you have `NUGET_API_KEY` defined as a secret variable for your repo or org, any nuget packages in the `deployables` artifact will be pushed to nuget.org.
+
+### Azure Pipelines
+
+When your repo builds with Azure Pipelines, use the `azure-pipelines/release.yml` pipeline.
+Trigger the pipeline by adding the `auto-release` tag on a run of your main `azure-pipelines.yml` pipeline.
+
 ## Tutorial and API documentation
 
 API and hand-written docs are found under the `docfx/` directory. and are built by [docfx](https://dotnet.github.io/docfx/).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(AspNetWebAssemblyVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetWebAssemblyVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(RoslynVersion)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="NBitcoin.Secp256k1" Version="3.1.6" />
@@ -26,16 +25,21 @@
     <PackageVersion Include="QRCoder" Version="1.6.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="xunit.combinatorial" Version="1.6.24" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageVersion Include="xunit.combinatorial" Version="2.0.5-alpha" />
+  </ItemGroup>
+  <ItemGroup Label="Library.Template">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit.v3" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Put repo-specific GlobalPackageReference items in this group. -->
+  </ItemGroup>
+  <ItemGroup Label="Library.Template">
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.112" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="$(RoslynVersion)" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - main
+    - 'v*.*'
     - 'validate/*'
   paths:
     exclude:

--- a/azure-pipelines/artifacts/coverageResults.ps1
+++ b/azure-pipelines/artifacts/coverageResults.ps1
@@ -3,14 +3,16 @@ $RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
 $coverageFiles = @(Get-ChildItem "$RepoRoot/test/*.cobertura.xml" -Recurse | Where {$_.FullName -notlike "*/In/*"  -and $_.FullName -notlike "*\In\*" })
 
 # Prepare code coverage reports for merging on another machine
-if ($env:SYSTEM_DEFAULTWORKINGDIRECTORY) {
-    Write-Host "Substituting $env:SYSTEM_DEFAULTWORKINGDIRECTORY with `"{reporoot}`""
+$repoRoot = $env:SYSTEM_DEFAULTWORKINGDIRECTORY
+if (!$repoRoot) { $repoRoot = $env:GITHUB_WORKSPACE }
+if ($repoRoot) {
+    Write-Host "Substituting $repoRoot with `"{reporoot}`""
     $coverageFiles |% {
-        $content = Get-Content -LiteralPath $_ |% { $_ -Replace [regex]::Escape($env:SYSTEM_DEFAULTWORKINGDIRECTORY), "{reporoot}" }
+        $content = Get-Content -LiteralPath $_ |% { $_ -Replace [regex]::Escape($repoRoot), "{reporoot}" }
         Set-Content -LiteralPath $_ -Value $content -Encoding UTF8
     }
 } else {
-    Write-Warning "coverageResults: Azure Pipelines not detected. Machine-neutral token replacement skipped."
+    Write-Warning "coverageResults: Cloud build not detected. Machine-neutral token replacement skipped."
 }
 
 if (!((Test-Path $RepoRoot\bin) -and (Test-Path $RepoRoot\obj))) { return }

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -1,5 +1,5 @@
+items:
 - name: Features
   href: features.md
 - name: Getting Started
   href: getting-started.md
-

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -1,3 +1,4 @@
+items:
 - name: Docs
   href: docs/
 - name: API

--- a/test/Nerdbank.Bitcoin.Tests/Nerdbank.Bitcoin.Tests.csproj
+++ b/test/Nerdbank.Bitcoin.Tests/Nerdbank.Bitcoin.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <RootNamespace />
   </PropertyGroup>
 
@@ -10,7 +11,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Nerdbank.Bitcoin.Tests/Usings.cs
+++ b/test/Nerdbank.Bitcoin.Tests/Usings.cs
@@ -4,5 +4,4 @@
 global using Nerdbank.Bitcoin;
 global using Nerdbank.Cryptocurrencies;
 global using Xunit;
-global using Xunit.Abstractions;
 global using static TestUtilities;

--- a/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/HistoricalPriceTestBase.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Exchanges/HistoricalPriceTestBase.cs
@@ -12,10 +12,10 @@ public abstract class HistoricalPriceTestBase(ITestOutputHelper logger) : TestBa
 
 	protected virtual string? SkipGetExchangeRateTests => null;
 
-	[SkippableTheory, PairwiseData]
+	[Theory, PairwiseData]
 	public async Task GetExchangeRateAsync_RespectsPairOrdering(bool fiatSecond)
 	{
-		Skip.If(this.SkipGetExchangeRateTests is not null, this.SkipGetExchangeRateTests);
+		Assert.SkipWhen(this.SkipGetExchangeRateTests is not null, this.SkipGetExchangeRateTests ?? "Not skipped");
 
 		TradingPair pair = UsdZec;
 		if (fiatSecond)
@@ -55,10 +55,10 @@ public abstract class HistoricalPriceTestBase(ITestOutputHelper logger) : TestBa
 		}
 	}
 
-	[SkippableFact]
+	[Fact]
 	public async Task GetHistoricalPricing_Now()
 	{
-		Skip.If(this.SkipGetExchangeRateTests is not null, this.SkipGetExchangeRateTests);
+		Assert.SkipWhen(this.SkipGetExchangeRateTests is not null, this.SkipGetExchangeRateTests ?? "Not skipped");
 
 		DateTimeOffset when = DateTimeOffset.Now;
 		ExchangeRate? rate = await this.Provider.GetExchangeRateAsync(UsdZec, when, this.TimeoutToken);

--- a/test/Nerdbank.Cryptocurrencies.Tests/Nerdbank.Cryptocurrencies.Tests.csproj
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Nerdbank.Cryptocurrencies.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <RootNamespace />
   </PropertyGroup>
 
@@ -10,8 +11,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="Xunit.SkippableFact" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Nerdbank.Cryptocurrencies.Tests/Usings.cs
+++ b/test/Nerdbank.Cryptocurrencies.Tests/Usings.cs
@@ -3,4 +3,3 @@
 
 global using Nerdbank.Cryptocurrencies;
 global using Xunit;
-global using Xunit.Abstractions;

--- a/test/Nerdbank.Zcash.Tests/LightWalletClientTests.cs
+++ b/test/Nerdbank.Zcash.Tests/LightWalletClientTests.cs
@@ -25,7 +25,7 @@ public class LightWalletClientTests : TestBase, IDisposable, IAsyncLifetime
 			Path.Join(this.testDir, "zcash-test.wallet"));
 	}
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		if (!defaultAccountBirthdayHeightSet)
 		{
@@ -36,9 +36,9 @@ public class LightWalletClientTests : TestBase, IDisposable, IAsyncLifetime
 		await this.client.AddAccountAsync(DefaultAccount, this.TimeoutToken);
 	}
 
-	public Task DisposeAsync()
+	public ValueTask DisposeAsync()
 	{
-		return Task.CompletedTask;
+		return ValueTask.CompletedTask;
 	}
 
 	public void Dispose()

--- a/test/Nerdbank.Zcash.Tests/ManagedLightWalletClientTests.cs
+++ b/test/Nerdbank.Zcash.Tests/ManagedLightWalletClientTests.cs
@@ -7,17 +7,17 @@ public class ManagedLightWalletClientTests : TestBase, IAsyncLifetime
 	private ManagedLightWalletClient mainnet = null!; // initialized in InitializeAsync
 	private ManagedLightWalletClient testnet = null!; // initialized in InitializeAsync
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		this.mainnet = await ManagedLightWalletClient.CreateAsync(LightWalletServerMainNet, this.TimeoutToken);
 		this.testnet = await ManagedLightWalletClient.CreateAsync(LightWalletServerTestNet, this.TimeoutToken);
 	}
 
-	public Task DisposeAsync()
+	public ValueTask DisposeAsync()
 	{
 		this.mainnet.Dispose();
 		this.testnet.Dispose();
-		return Task.CompletedTask;
+		return ValueTask.CompletedTask;
 	}
 
 	[Fact]

--- a/test/Nerdbank.Zcash.Tests/Nerdbank.Zcash.Tests.csproj
+++ b/test/Nerdbank.Zcash.Tests/Nerdbank.Zcash.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <RootNamespace />
     <RuntimeIdentifiers>$(AvailableRuntimeIdentifiers)</RuntimeIdentifiers>
     <RuntimeIdentifier>$(DefaultRuntimeIdentifier)</RuntimeIdentifier>
@@ -16,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.combinatorial" />
   </ItemGroup>
 

--- a/test/Nerdbank.Zcash.Tests/Usings.cs
+++ b/test/Nerdbank.Zcash.Tests/Usings.cs
@@ -4,4 +4,3 @@
 global using Nerdbank.Cryptocurrencies;
 global using Nerdbank.Zcash;
 global using Xunit;
-global using Xunit.Abstractions;


### PR DESCRIPTION
- **Add docfx verification to build**
- **Fix nb.gv failure during docfx build**
- **Remove double word from boilerplate docfx text**
- **Bump docfx to 2.78.2**
- **Bump dotnet-coverage to 17.13.1**
- **Move artifact publishing into a composite action**
- **Make the CI workflow dispatchable**
- **Fix docfx build on private repos**
- **Fix code coverage merge on GitHub Actions**
- **Add release workflow**
- **Document release process**
- **Publish test results when they fail on github workflows**
- **Fix push to nuget.org in github release workflow**
- **Bump nbgv and Nerdbank.GitVersioning to 3.7.112**
- **Activate GitHub Actions test reporting**
- **Revert "Merge pull request #319 from AArnott/betterTestingLibTemplate"**
- **Resolve schema validation error in VS Code for docfx yml files**
- **Bump xunit.runner.visualstudio to 3.0.0**
- **Bump .NET SDK to 9.0.101**
- **Organize Directory.Packages.props to reduce merge conflicts going forward**
- **Bump to Xunit v3**
- **Build servicing branches**
- **Do not publish artifacts on cancelled GitHub workflows**
