### PR TITLE
Fix renovate's ability to update rust dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,23 +1,26 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "semanticCommits": "disabled",
-  "labels": ["dependencies"],
-  "packageRules": [
-    {
-      "matchPackageNames": ["nbgv", "nerdbank.gitversioning"],
-      "groupName": "nbgv and nerdbank.gitversioning updates"
-    },
-    {
-      "matchPackageNames": ["xunit*"],
-      "groupName": "xunit"
-    },
-    {
-      "matchDatasources": ["dotnet-version", "docker"],
-      "matchDepNames": ["dotnet-sdk", "mcr.microsoft.com/dotnet/sdk"],
-      "groupName": "Dockerfile and global.json updates"
-    }
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"git-submodules": {
+		"enabled": true,
+		"versioning": "git",
+		"fileMatch": []
+	},
+	"semanticCommits": "disabled",
+	"labels": ["dependencies"],
+	"packageRules": [
+		{
+			"matchPackageNames": ["nbgv", "nerdbank.gitversioning"],
+			"groupName": "nbgv and nerdbank.gitversioning updates"
+		},
+		{
+			"matchPackageNames": ["xunit*"],
+			"groupName": "xunit"
+		},
+		{
+			"matchDatasources": ["dotnet-version", "docker"],
+			"matchDepNames": ["dotnet-sdk", "mcr.microsoft.com/dotnet/sdk"],
+			"groupName": "Dockerfile and global.json updates"
+		}
+	]
 }


### PR DESCRIPTION
The rust crate depends on a git submodule being cloned down, so I'm trying to activate this behavior in Renovate without actually having it modify the submodules themselves.